### PR TITLE
fix: remove leftover merge conflict markers3

### DIFF
--- a/src/main/java/pbl2/sub119/backend/auth/entity/OauthUser.java
+++ b/src/main/java/pbl2/sub119/backend/auth/entity/OauthUser.java
@@ -1,10 +1,8 @@
 package pbl2.sub119.backend.auth.entity;
 
-<<<<<<< HEAD
-import pbl2.submate.backend.auth.enumerated.SocialProvider;
-=======
 import pbl2.sub119.backend.auth.enumerated.SocialProvider;
->>>>>>> 2ee923e (fix: 소프트 삭제 및 재가입 로직 개선, merge 충돌 해결)
+import pbl2.sub119.backend.common.enumerated.UserRole;
+
 
 public interface OauthUser {
     Long getId();

--- a/src/main/java/pbl2/sub119/backend/test/controller/TestController.java
+++ b/src/main/java/pbl2/sub119/backend/test/controller/TestController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import pbl2.submate.backend.test.dto.TestResponse;
+import pbl2.sub119.backend.test.dto.TestResponse;
 import pbl2.sub119.backend.test.service.TestService;
 
 @RestController

--- a/src/main/java/pbl2/sub119/backend/test/service/TestService.java
+++ b/src/main/java/pbl2/sub119/backend/test/service/TestService.java
@@ -1,10 +1,6 @@
 package pbl2.sub119.backend.test.service;
 
-<<<<<<< HEAD
-import pbl2.submate.backend.test.dto.TestResponse;
-=======
 import pbl2.sub119.backend.test.dto.TestResponse;
->>>>>>> 2ee923e (fix: 소프트 삭제 및 재가입 로직 개선, merge 충돌 해결)
 
 public interface TestService {
     TestResponse getTest(Long id);

--- a/src/main/java/pbl2/sub119/backend/test/service/TestServiceImpl.java
+++ b/src/main/java/pbl2/sub119/backend/test/service/TestServiceImpl.java
@@ -2,7 +2,7 @@ package pbl2.sub119.backend.test.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import pbl2.submate.backend.test.dto.TestResponse;
+import pbl2.sub119.backend.test.dto.TestResponse;
 import pbl2.sub119.backend.test.mapper.TestMapper;
 import pbl2.sub119.backend.test.vo.TestVO;
 

--- a/src/main/java/pbl2/sub119/backend/user/service/UserService.java
+++ b/src/main/java/pbl2/sub119/backend/user/service/UserService.java
@@ -3,23 +3,16 @@ package pbl2.sub119.backend.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-<<<<<<< HEAD
-import pbl2.submate.backend.auth.entity.Accessor;
-=======
 import pbl2.sub119.backend.auth.entity.Accessor;
->>>>>>> 2ee923e (fix: 소프트 삭제 및 재가입 로직 개선, merge 충돌 해결)
 import pbl2.sub119.backend.common.enumerated.UserStatus;
 import pbl2.sub119.backend.user.dto.request.UserRequest;
 import pbl2.sub119.backend.user.dto.response.UserResponse;
 import pbl2.sub119.backend.user.dto.response.UserSignUpResponse;
 import pbl2.sub119.backend.user.dto.response.UserUpdateResponse;
-<<<<<<< HEAD
-import pbl2.submate.backend.user.entity.UserEntity;
-import pbl2.submate.backend.user.mapper.UserMapper;
-=======
+
 import pbl2.sub119.backend.user.entity.UserEntity;
 import pbl2.sub119.backend.user.mapper.UserMapper;
->>>>>>> 2ee923e (fix: 소프트 삭제 및 재가입 로직 개선, merge 충돌 해결)
+
 import pbl2.sub119.backend.user.util.PinEncoder;
 
 @Service


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타(Chores)**
  * 내부 패키지 참조를 정규화하여 코드 일관성을 개선했습니다.
  * 병합 충돌 마크업을 정리하여 빌드 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->