### PR TITLE
[Party Operation] 결제 성공 후 운영 자동 open/reset 연동 구현

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/service/PartyCycleService.java
+++ b/src/main/java/pbl2/sub119/backend/party/service/PartyCycleService.java
@@ -14,6 +14,7 @@ import pbl2.sub119.backend.party.enumerated.VacancyType;
 import pbl2.sub119.backend.party.exception.PartyException;
 import pbl2.sub119.backend.party.mapper.PartyMapper;
 import pbl2.sub119.backend.party.mapper.PartyMemberMapper;
+import pbl2.sub119.backend.partyoperation.service.PartyOperationCommandService;
 
 @Service
 @RequiredArgsConstructor
@@ -22,18 +23,23 @@ public class PartyCycleService {
     private final PartyMapper partyMapper;
     private final PartyMemberMapper partyMemberMapper;
     private final PartyHistoryService partyHistoryService;
+    private final PartyOperationCommandService partyOperationCommandService;
 
+    // 결제 성공 후 시작되는 이용 주기 기준으로 파티 상태를 반영
     @Transactional
     public void handleCycleStart(Long partyId) {
+
         Party party = partyMapper.findByIdForUpdate(partyId);
         if (party == null) {
             throw new PartyException(ErrorCode.PARTY_NOT_FOUND);
         }
 
+        // 이번 결제일 기준으로 탈퇴 예정 멤버를 실제 탈퇴 처리
         List<PartyMember> leaveReservedMembers = partyMemberMapper.findLeaveReservedMembers(partyId);
         for (PartyMember member : leaveReservedMembers) {
             partyMemberMapper.updateStatusAndLeftAt(member.getId(), PartyMemberStatus.LEFT);
 
+            // 파티 이력에 탈퇴 반영 기록 저장
             partyHistoryService.saveHistory(
                     partyId,
                     member.getId(),
@@ -43,14 +49,17 @@ public class PartyCycleService {
             );
         }
 
+        // 결원 충원 대기 멤버를 이번 주기부터 실제 이용 가능 상태로 전환
         List<PartyMember> switchWaitingMembers = partyMemberMapper.findSwitchWaitingMembers(partyId);
         for (PartyMember member : switchWaitingMembers) {
             partyMemberMapper.updateStatusAndActivatedAt(member.getId(), PartyMemberStatus.ACTIVE);
         }
 
+        // 결제일 반영 후 실제 점유 인원 수를 다시 계산
         int occupiedCount = partyMemberMapper.countOccupiedMembers(partyId);
         partyMapper.updateCurrentMemberCount(partyId, occupiedCount);
 
+        // 현재 인원 기준으로 모집 상태와 결원 유형 갱신
         if (occupiedCount >= party.getCapacity()) {
             partyMapper.updateRecruitStatus(partyId, RecruitStatus.FULL);
             partyMapper.updateVacancyType(partyId, VacancyType.NONE);
@@ -58,5 +67,8 @@ public class PartyCycleService {
             partyMapper.updateRecruitStatus(partyId, RecruitStatus.RECRUITING);
             partyMapper.updateVacancyType(partyId, VacancyType.MEMBER);
         }
+
+        // 주기 시작 후 멤버 변경 결과를 기준으로 운영 상태도 후속 반영
+        partyOperationCommandService.handleCycleStart(partyId);
     }
 }

--- a/src/main/java/pbl2/sub119/backend/partyoperation/mapper/PartyOperationMapper.java
+++ b/src/main/java/pbl2/sub119/backend/partyoperation/mapper/PartyOperationMapper.java
@@ -53,4 +53,12 @@ public interface PartyOperationMapper {
             @Param("lastResetAt") LocalDateTime lastResetAt,
             @Param("updatedAt") LocalDateTime updatedAt
     );
+
+    void updateCycleStartResetState(
+            @Param("id") Long id,
+            @Param("operationStatus") OperationStatus operationStatus,
+            @Param("operationStartedAt") LocalDateTime operationStartedAt,
+            @Param("lastResetAt") LocalDateTime lastResetAt,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 }

--- a/src/main/java/pbl2/sub119/backend/partyoperation/mapper/PartyOperationMemberMapper.java
+++ b/src/main/java/pbl2/sub119/backend/partyoperation/mapper/PartyOperationMemberMapper.java
@@ -22,6 +22,10 @@ public interface PartyOperationMemberMapper {
             @Param("userId") Long userId
     );
 
+    List<PartyOperationMember> findByPartyOperationId(
+            @Param("partyOperationId") Long partyOperationId
+    );
+
     List<PartyOperationMemberResponse> findResponsesByPartyOperationId(
             @Param("partyOperationId") Long partyOperationId
     );

--- a/src/main/java/pbl2/sub119/backend/partyoperation/service/PartyOperationCommandService.java
+++ b/src/main/java/pbl2/sub119/backend/partyoperation/service/PartyOperationCommandService.java
@@ -2,6 +2,8 @@ package pbl2.sub119.backend.partyoperation.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +30,9 @@ import pbl2.sub119.backend.partyoperation.mapper.PartyOperationMemberMapper;
 @RequiredArgsConstructor
 @Transactional
 public class PartyOperationCommandService {
+
+    private static final String CYCLE_MEMBER_CHANGED_MESSAGE =
+            "결제일 기준 멤버 변경이 반영되어 운영 재설정이 필요합니다.";
 
     private final PartyMapper partyMapper;
     private final PartyMemberMapper partyMemberMapper;
@@ -110,6 +115,51 @@ public class PartyOperationCommandService {
         );
     }
 
+    // cycle start 이후 운영 자동 상태 반영
+    public void handleCycleStart(final Long partyId) {
+        final Party party = getParty(partyId);
+        final PartyOperation operation = partyOperationMapper.findByPartyIdForUpdate(partyId);
+
+        // 아직 운영 정보가 등록되지 않은 파티는 후속 처리하지 않음
+        if (operation == null) {
+            return;
+        }
+
+
+        final List<PartyMember> currentTargetMembers =
+                partyMemberMapper.findOperationTargetMembersByPartyId(partyId);
+
+        final List<PartyOperationMember> existingOperationMembers =
+                partyOperationMemberMapper.findByPartyOperationId(operation.getId());
+
+        final boolean memberChanged = hasOperationTargetChanged(currentTargetMembers, existingOperationMembers);
+
+        // 멤버 변경이 없으면 기존 운영 상태 유지
+        if (!memberChanged) {
+            return;
+        }
+
+        final LocalDateTime now = LocalDateTime.now();
+
+        partyOperationMapper.updateCycleStartResetState(
+                operation.getId(),
+                OperationStatus.RESET_REQUIRED,
+                operation.getOperationStartedAt(),
+                now,
+                now
+        );
+
+        resetMemberRows(operation.getId(), partyId, party.getHostUserId(), now);
+
+        partyOperationMemberMapper.markAllResetRequired(
+                operation.getId(),
+                OperationMemberStatus.RESET_REQUIRED,
+                CYCLE_MEMBER_CHANGED_MESSAGE,
+                now,
+                now
+        );
+    }
+
     // 파티원이 운영 완료를 확인하면 멤버 상태 및 파티 전체 운영 상태 갱신
     public PartyOperationConfirmResponse confirmOperation(
             final Long userId,
@@ -118,11 +168,11 @@ public class PartyOperationCommandService {
         final PartyOperation operation = getOperationForUpdate(partyId);
 
         if (operation.getOperationStatus() == OperationStatus.ACTIVE) {
-                    throw new PartyException(ErrorCode.PARTY_OPERATION_ALREADY_ACTIVE);
-                }
+            throw new PartyException(ErrorCode.PARTY_OPERATION_ALREADY_ACTIVE);
+        }
 
         if (operation.getOperationStatus() == OperationStatus.RESET_REQUIRED) {
-                  throw new PartyException(ErrorCode.PARTY_OPERATION_RESET_REQUIRED);
+            throw new PartyException(ErrorCode.PARTY_OPERATION_RESET_REQUIRED);
         }
 
         final PartyOperationMember member = getOperationMember(partyId, userId);
@@ -136,6 +186,7 @@ public class PartyOperationCommandService {
                     member.getActivatedAt()
             );
         }
+
         final LocalDateTime now = LocalDateTime.now();
 
         partyOperationMemberMapper.markActive(
@@ -259,6 +310,25 @@ public class PartyOperationCommandService {
                 OperationStatus.IN_PROGRESS,
                 now
         );
+    }
+
+    private boolean hasOperationTargetChanged(
+            final List<PartyMember> currentTargetMembers,
+            final List<PartyOperationMember> existingOperationMembers
+    ) {
+        if (currentTargetMembers.size() != existingOperationMembers.size()) {
+            return true;
+        }
+
+        final Set<Long> currentPartyMemberIds = currentTargetMembers.stream()
+                .map(PartyMember::getId)
+                .collect(Collectors.toSet());
+
+        final Set<Long> existingPartyMemberIds = existingOperationMembers.stream()
+                .map(PartyOperationMember::getPartyMemberId)
+                .collect(Collectors.toSet());
+
+        return !currentPartyMemberIds.equals(existingPartyMemberIds);
     }
 
     // 파티 조회

--- a/src/main/resources/mapper/partyoperation/PartyOperationMapper.xml
+++ b/src/main/resources/mapper/partyoperation/PartyOperationMapper.xml
@@ -124,10 +124,10 @@
     <update id="updateStatusIfNotActive">
         UPDATE party_operation
         SET
-        operation_status = #{operationStatus},
-        updated_at = #{updatedAt}
+            operation_status = #{operationStatus},
+            updated_at = #{updatedAt}
         WHERE id = #{id}
-        AND operation_status  &lt;&gt; 'ACTIVE'
+          AND operation_status &lt;&gt; 'ACTIVE'
     </update>
 
     <!-- 전원 완료 시 운영 상태 ACTIVE + 완료 시각 기록 -->
@@ -147,6 +147,18 @@
             operation_status = #{operationStatus},
             last_reset_at = #{lastResetAt},
             operation_completed_at = NULL,
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- cycle start 이후 멤버 변경 발생 시 운영 재설정 처리 -->
+    <update id="updateCycleStartResetState">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            operation_started_at = #{operationStartedAt},
+            operation_completed_at = NULL,
+            last_reset_at = #{lastResetAt},
             updated_at = #{updatedAt}
         WHERE id = #{id}
     </update>

--- a/src/main/resources/mapper/partyoperation/PartyOperationMemberMapper.xml
+++ b/src/main/resources/mapper/partyoperation/PartyOperationMemberMapper.xml
@@ -131,6 +131,15 @@
         LIMIT 1
     </select>
 
+    <!--cycle start 이후 현재 운영 멤버 구성 비교용 조회-->
+    <select id="findByPartyOperationId" resultMap="partyOperationMemberResultMap">
+        SELECT
+        <include refid="partyOperationMemberColumns"/>
+        FROM party_operation_member
+        WHERE party_operation_id = #{partyOperationId}
+        ORDER BY id ASC
+    </select>
+
     <!--파티장/파티원이 운영 현황 확인할 때 전체 멤버 상태 리스트 반환-->
     <select id="findResponsesByPartyOperationId" resultMap="partyOperationMemberResponseResultMap">
         SELECT
@@ -165,7 +174,6 @@
         WHERE party_operation_id = #{partyOperationId}
           AND member_status = 'ACTIVE'
     </select>
-
 
     <select id="countByPartyIdAndUserId" resultType="int">
         SELECT COUNT(*)

--- a/src/test/java/pbl2/sub119/backend/partyoperation/service/PartyCycleServiceTest.java
+++ b/src/test/java/pbl2/sub119/backend/partyoperation/service/PartyCycleServiceTest.java
@@ -1,0 +1,378 @@
+package pbl2.sub119.backend.partyoperation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import pbl2.sub119.backend.party.entity.Party;
+import pbl2.sub119.backend.party.entity.PartyMember;
+import pbl2.sub119.backend.party.enumerated.OperationStatus;
+import pbl2.sub119.backend.party.enumerated.PartyMemberStatus;
+import pbl2.sub119.backend.party.enumerated.PartyRole;
+import pbl2.sub119.backend.party.enumerated.RecruitStatus;
+import pbl2.sub119.backend.party.enumerated.VacancyType;
+import pbl2.sub119.backend.party.mapper.PartyMapper;
+import pbl2.sub119.backend.party.mapper.PartyMemberMapper;
+import pbl2.sub119.backend.party.service.PartyCycleService;
+import pbl2.sub119.backend.partyoperation.dto.response.PartyOperationMemberResponse;
+import pbl2.sub119.backend.partyoperation.entity.PartyOperation;
+import pbl2.sub119.backend.partyoperation.entity.PartyOperationMember;
+import pbl2.sub119.backend.partyoperation.enumerated.OperationMemberStatus;
+import pbl2.sub119.backend.partyoperation.enumerated.OperationType;
+import pbl2.sub119.backend.partyoperation.mapper.PartyOperationMapper;
+import pbl2.sub119.backend.partyoperation.mapper.PartyOperationMemberMapper;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+class PartyCycleServiceTest {
+
+    @Autowired
+    private PartyCycleService partyCycleService;
+
+    @Autowired
+    private PartyMapper partyMapper;
+
+    @Autowired
+    private PartyMemberMapper partyMemberMapper;
+
+    @Autowired
+    private PartyOperationMapper partyOperationMapper;
+
+    @Autowired
+    private PartyOperationMemberMapper partyOperationMemberMapper;
+
+    @Test
+    @DisplayName("cycle start 시 멤버 변경이 없으면 운영 상태를 그대로 유지한다")
+    void handleCycleStartWithoutMemberChangeKeepsOperationState() {
+        // given
+        Long partyId = createParty(4, 4);
+
+        createMember(partyId, 1L, PartyRole.HOST, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 2L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 3L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 4L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+
+        Long operationId = createOperation(
+                partyId,
+                pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.ACTIVE
+        );
+
+        // 현재 운영 멤버와 실제 파티 멤버 구성이 동일한 상태
+        createOperationMembersByUserIds(operationId, partyId, List.of(1L, 2L, 3L, 4L));
+
+        // when
+        partyCycleService.handleCycleStart(partyId);
+
+        // then
+        Party updatedParty = partyMapper.findById(partyId);
+
+        // 멤버 변화가 없으므로 인원/모집/결원 상태 유지
+        assertThat(updatedParty.getCurrentMemberCount()).isEqualTo(4);
+        assertThat(updatedParty.getRecruitStatus()).isEqualTo(RecruitStatus.FULL);
+        assertThat(updatedParty.getVacancyType()).isEqualTo(VacancyType.NONE);
+
+        PartyOperation updatedOperation = partyOperationMapper.findByPartyId(partyId);
+
+        // 운영 상태도 그대로 유지되어야 함
+        assertThat(updatedOperation.getOperationStatus())
+                .isEqualTo(pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.ACTIVE);
+        assertThat(updatedOperation.getLastResetAt()).isNull();
+        assertThat(updatedOperation.getOperationCompletedAt()).isNotNull();
+
+        List<PartyOperationMemberResponse> operationMembers =
+                partyOperationMemberMapper.findResponsesByPartyOperationId(operationId);
+
+        // 운영 멤버도 그대로 4명 유지
+        assertThat(operationMembers).hasSize(4);
+        assertThat(operationMembers.stream()
+                .map(PartyOperationMemberResponse::userId)
+                .toList())
+                .containsExactly(1L, 2L, 3L, 4L);
+    }
+
+    @Test
+    @DisplayName("cycle start 시 탈퇴 예정 멤버를 실제 탈퇴 처리하고 운영을 RESET_REQUIRED로 전환한다")
+    void handleCycleStartWithLeaveReservedMemberResetsOperation() {
+        // given
+        Long partyId = createParty(4, 4);
+
+        createMember(partyId, 1L, PartyRole.HOST, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 2L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 3L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 4L, PartyRole.MEMBER, PartyMemberStatus.LEAVE_RESERVED);
+
+        Long operationId = createOperation(
+                partyId,
+                pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.ACTIVE
+        );
+
+        // 이전 주기 기준 운영 멤버 구성
+        createOperationMembersByUserIds(operationId, partyId, List.of(1L, 2L, 3L, 4L));
+
+        // when
+        partyCycleService.handleCycleStart(partyId);
+
+        // then
+        Map<Long, PartyMember> membersByUserId = partyMemberMapper.findMembersByPartyId(partyId)
+                .stream()
+                .collect(Collectors.toMap(PartyMember::getUserId, Function.identity()));
+
+        // 탈퇴 예약 멤버는 실제 탈퇴 처리
+        PartyMember leftMember = membersByUserId.get(4L);
+        assertThat(leftMember.getStatus()).isEqualTo(PartyMemberStatus.LEFT);
+        assertThat(leftMember.getLeftAt()).isNotNull();
+
+        Party updatedParty = partyMapper.findById(partyId);
+
+        // 인원 감소 -> 모집중 / 파티원 결원
+        assertThat(updatedParty.getCurrentMemberCount()).isEqualTo(3);
+        assertThat(updatedParty.getRecruitStatus()).isEqualTo(RecruitStatus.RECRUITING);
+        assertThat(updatedParty.getVacancyType()).isEqualTo(VacancyType.MEMBER);
+
+        PartyOperation updatedOperation = partyOperationMapper.findByPartyId(partyId);
+
+        // 운영 멤버 구성이 바뀌었으므로 reset 필요
+        assertThat(updatedOperation.getOperationStatus())
+                .isEqualTo(pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.RESET_REQUIRED);
+        assertThat(updatedOperation.getLastResetAt()).isNotNull();
+        assertThat(updatedOperation.getOperationCompletedAt()).isNull();
+
+        List<PartyOperationMemberResponse> operationMembers =
+                partyOperationMemberMapper.findResponsesByPartyOperationId(operationId);
+
+        // 남아 있는 3명 기준으로 재생성되어야 함
+        assertThat(operationMembers).hasSize(3);
+        assertThat(operationMembers.stream()
+                .map(PartyOperationMemberResponse::userId)
+                .toList())
+                .containsExactlyInAnyOrder(1L, 2L, 3L);
+
+        // reset 처리 후 운영 멤버 상태는 전원 RESET_REQUIRED
+        assertThat(operationMembers)
+                .extracting(PartyOperationMemberResponse::memberStatus)
+                .containsOnly(OperationMemberStatus.RESET_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("cycle start 시 교체 대기 멤버를 ACTIVE로 전환하고 운영 멤버를 새 기준으로 재구성한다")
+    void handleCycleStartWithSwitchWaitingMemberRebuildsOperationMembers() {
+        // given
+        Long partyId = createParty(4, 4);
+
+        createMember(partyId, 1L, PartyRole.HOST, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 2L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 3L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 4L, PartyRole.MEMBER, PartyMemberStatus.LEAVE_RESERVED);
+        createMember(partyId, 5L, PartyRole.MEMBER, PartyMemberStatus.SWITCH_WAITING);
+
+        Long operationId = createOperation(
+                partyId,
+                pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.ACTIVE
+        );
+
+        // 이전 주기 기준 운영 멤버는 1,2,3,4
+        createOperationMembersByUserIds(operationId, partyId, List.of(1L, 2L, 3L, 4L));
+
+        // when
+        partyCycleService.handleCycleStart(partyId);
+
+        // then
+        Map<Long, PartyMember> membersByUserId = partyMemberMapper.findMembersByPartyId(partyId)
+                .stream()
+                .collect(Collectors.toMap(PartyMember::getUserId, Function.identity()));
+
+        // 기존 탈퇴 예정자는 LEFT
+        assertThat(membersByUserId.get(4L).getStatus()).isEqualTo(PartyMemberStatus.LEFT);
+        assertThat(membersByUserId.get(4L).getLeftAt()).isNotNull();
+
+        // 교체 대기 멤버는 이번 주기부터 ACTIVE
+        assertThat(membersByUserId.get(5L).getStatus()).isEqualTo(PartyMemberStatus.ACTIVE);
+        assertThat(membersByUserId.get(5L).getActivatedAt()).isNotNull();
+
+        Party updatedParty = partyMapper.findById(partyId);
+
+        // 빠진 인원과 새 인원이 교체되므로 총 인원은 다시 4명
+        assertThat(updatedParty.getCurrentMemberCount()).isEqualTo(4);
+        assertThat(updatedParty.getRecruitStatus()).isEqualTo(RecruitStatus.FULL);
+        assertThat(updatedParty.getVacancyType()).isEqualTo(VacancyType.NONE);
+
+        PartyOperation updatedOperation = partyOperationMapper.findByPartyId(partyId);
+
+        // 운영 멤버가 바뀌었으므로 reset 필요
+        assertThat(updatedOperation.getOperationStatus())
+                .isEqualTo(pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.RESET_REQUIRED);
+        assertThat(updatedOperation.getLastResetAt()).isNotNull();
+        assertThat(updatedOperation.getOperationCompletedAt()).isNull();
+
+        List<PartyOperationMemberResponse> operationMembers =
+                partyOperationMemberMapper.findResponsesByPartyOperationId(operationId);
+
+        // 새 운영 멤버는 1,2,3,5 기준으로 재구성
+        assertThat(operationMembers).hasSize(4);
+        assertThat(operationMembers.stream()
+                .map(PartyOperationMemberResponse::userId)
+                .toList())
+                .containsExactlyInAnyOrder(1L, 2L, 3L, 5L);
+
+        // reset 처리 후 운영 멤버 상태는 전원 RESET_REQUIRED
+        assertThat(operationMembers)
+                .extracting(PartyOperationMemberResponse::memberStatus)
+                .containsOnly(OperationMemberStatus.RESET_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("cycle start 시 운영 정보가 없어도 파티 상태만 반영하고 예외 없이 완료한다")
+    void handleCycleStartWithoutOperationPassesSilently() {
+        // given
+        Long partyId = createParty(4, 4);
+
+        createMember(partyId, 1L, PartyRole.HOST, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 2L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 3L, PartyRole.MEMBER, PartyMemberStatus.ACTIVE);
+        createMember(partyId, 4L, PartyRole.MEMBER, PartyMemberStatus.LEAVE_RESERVED);
+
+        // when
+        partyCycleService.handleCycleStart(partyId);
+
+        // then
+        Map<Long, PartyMember> membersByUserId = partyMemberMapper.findMembersByPartyId(partyId)
+                .stream()
+                .collect(Collectors.toMap(PartyMember::getUserId, Function.identity()));
+
+        // 파티 상태는 정상 반영
+        assertThat(membersByUserId.get(4L).getStatus()).isEqualTo(PartyMemberStatus.LEFT);
+
+        Party updatedParty = partyMapper.findById(partyId);
+        assertThat(updatedParty.getCurrentMemberCount()).isEqualTo(3);
+        assertThat(updatedParty.getRecruitStatus()).isEqualTo(RecruitStatus.RECRUITING);
+        assertThat(updatedParty.getVacancyType()).isEqualTo(VacancyType.MEMBER);
+
+        // 운영 정보가 없어도 예외 없이 지나가야 함
+        PartyOperation operation = partyOperationMapper.findByPartyId(partyId);
+        assertThat(operation).isNull();
+    }
+
+    // 파티 기본 데이터 생성
+    private Long createParty(int capacity, int currentMemberCount) {
+        Party party = Party.builder()
+                .productId("TEST_PRODUCT_" + System.nanoTime())
+                .hostUserId(1L)
+                .capacity(capacity)
+                .currentMemberCount(currentMemberCount)
+                .recruitStatus(currentMemberCount >= capacity ? RecruitStatus.FULL : RecruitStatus.RECRUITING)
+                .operationStatus(OperationStatus.WAITING_START)
+                .vacancyType(currentMemberCount >= capacity ? VacancyType.NONE : VacancyType.MEMBER)
+                .pricePerMemberSnapshot(5000)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .terminatedAt(null)
+                .build();
+
+        partyMapper.insertParty(party);
+        return party.getId();
+    }
+
+    // 파티 멤버 생성
+    private Long createMember(
+            Long partyId,
+            Long userId,
+            PartyRole role,
+            PartyMemberStatus status
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        PartyMember member = PartyMember.builder()
+                .partyId(partyId)
+                .userId(userId)
+                .role(role)
+                .status(status)
+                .joinedAt(now)
+                .activatedAt(status == PartyMemberStatus.ACTIVE ? now : null)
+                .serviceStartAt(null)
+                .serviceEndAt(null)
+                .leaveReservedAt(status == PartyMemberStatus.LEAVE_RESERVED ? now : null)
+                .leftAt(null)
+                .replacedTargetMemberId(null)
+                .build();
+
+        partyMemberMapper.insertPartyMember(member);
+        return member.getId();
+    }
+
+    // 파티 운영 정보 생성
+    private Long createOperation(
+            Long partyId,
+            pbl2.sub119.backend.partyoperation.enumerated.OperationStatus status
+    ) {
+        LocalDateTime now = LocalDateTime.now();
+
+        PartyOperation operation = PartyOperation.builder()
+                .partyId(partyId)
+                .operationType(OperationType.ACCOUNT_SHARED)
+                .operationStatus(status)
+                .inviteValue(null)
+                .sharedAccountEmail("shared@test.com")
+                .sharedAccountPasswordEncrypted("encrypted-password")
+                .operationGuide("테스트 운영 가이드")
+                .operationStartedAt(now.minusHours(1))
+                .operationCompletedAt(
+                        status == pbl2.sub119.backend.partyoperation.enumerated.OperationStatus.ACTIVE
+                                ? now
+                                : null
+                )
+                .lastResetAt(null)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        partyOperationMapper.insert(operation);
+        return operation.getId();
+    }
+
+    // 이전 주기 기준 운영 멤버를 특정 userId 목록으로만 생성
+    private void createOperationMembersByUserIds(
+            Long operationId,
+            Long partyId,
+            List<Long> userIds
+    ) {
+        Map<Long, PartyMember> membersByUserId = partyMemberMapper.findMembersByPartyId(partyId)
+                .stream()
+                .collect(Collectors.toMap(PartyMember::getUserId, Function.identity()));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        for (Long userId : userIds) {
+            PartyMember member = membersByUserId.get(userId);
+
+            PartyOperationMember operationMember = PartyOperationMember.builder()
+                    .partyOperationId(operationId)
+                    .partyMemberId(member.getId())
+                    .partyId(partyId)
+                    .userId(member.getUserId())
+                    .memberStatus(OperationMemberStatus.ACTIVE)
+                    .inviteSentAt(now)
+                    .mustCompleteBy(now.plusHours(24))
+                    .confirmedAt(now)
+                    .completedAt(now)
+                    .activatedAt(now)
+                    .lastResetAt(null)
+                    .penaltyApplied(false)
+                    .operationMessage("기존 운영 멤버")
+                    .createdAt(now)
+                    .updatedAt(now)
+                    .build();
+
+            partyOperationMemberMapper.insert(operationMember);
+        }
+    }
+}


### PR DESCRIPTION
cycle start 이후 운영 상태 연동 로직 및 PartyCycleService 통합테스트 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 파티 사이클 시작 시 운영 상태 관리 로직이 강화되었습니다.
  * 파티 멤버 구성 변화가 자동으로 감지되고 처리됩니다.
  * 사이클 시작 중 운영 상태 초기화 기능이 추가되었습니다.

* **테스트**
  * 사이클 시작 프로세스에 대한 포괄적인 통합 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->