### PR TITLE
[BANK] 계좌 연결/정산계좌 등록 기능 정리 및 문서화

### DIFF
--- a/src/main/java/pbl2/sub119/backend/bankaccounts/client/KftcApiClient.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/client/KftcApiClient.java
@@ -1,0 +1,126 @@
+package pbl2.sub119.backend.bankaccounts.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import pbl2.sub119.backend.bankaccounts.config.KftcProperties;
+import pbl2.sub119.backend.bankaccounts.dto.KftcAccountRealNameResponse;
+import pbl2.sub119.backend.bankaccounts.dto.KftcTokenResponse;
+import pbl2.sub119.backend.bankaccounts.dto.KftcUserInfoResponse;
+import pbl2.sub119.backend.common.exception.BusinessException;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_CONNECT_REQUEST_FAILED;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KftcApiClient {
+
+    private static final DateTimeFormatter TRAN_DTIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private final WebClient webClient;
+    private final KftcProperties kftcProperties;
+    private final ObjectMapper objectMapper;
+
+    public KftcTokenResponse requestToken(String code) {
+        try {
+            String tokenJson = webClient.post()
+                    .uri(kftcProperties.getBaseUrl() + "/oauth/2.0/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("code", code)
+                            .with("client_id", kftcProperties.getClientId())
+                            .with("client_secret", kftcProperties.getClientSecret())
+                            .with("redirect_uri", kftcProperties.getRedirectUrl())
+                            .with("grant_type", "authorization_code"))
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return objectMapper.readValue(tokenJson, KftcTokenResponse.class);
+        } catch (Exception e) {
+            log.error("KFTC token request failed", e);
+            throw new BusinessException(BANK_ACCOUNT_CONNECT_REQUEST_FAILED);
+        }
+    }
+
+    public KftcUserInfoResponse requestUserInfo(KftcTokenResponse tokenResponse) {
+        try {
+            String userJson = webClient.get()
+                    .uri(kftcProperties.getBaseUrl() + "/v2.0/user/me?user_seq_no=" + tokenResponse.getUserSeqNo())
+                    .header("Authorization", "Bearer " + tokenResponse.getAccessToken())
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return objectMapper.readValue(userJson, KftcUserInfoResponse.class);
+        } catch (Exception e) {
+            log.error("KFTC user info request failed", e);
+            throw new BusinessException(BANK_ACCOUNT_CONNECT_REQUEST_FAILED);
+        }
+    }
+
+    public KftcAccountRealNameResponse requestAccountRealName(
+            String accessToken,
+            String bankCode,
+            String accountNumber,
+            String accountHolderBirthDate,
+            String bankTranId
+    ) {
+        try {
+            String resolvedBankTranId = resolveBankTranId(bankTranId);
+            String tranDtime = LocalDateTime.now().format(TRAN_DTIME_FORMAT);
+
+            String uri = UriComponentsBuilder
+                    .fromUriString(kftcProperties.getBaseUrl() + "/v2.0/inquiry/real_name")
+                    .queryParam("bank_tran_id", resolvedBankTranId)
+                    .queryParam("bank_code_std", bankCode)
+                    .queryParam("account_num", accountNumber)
+                    .queryParam("account_holder_info_type", " ")
+                    .queryParam("account_holder_info", accountHolderBirthDate)
+                    .queryParam("tran_dtime", tranDtime)
+                    .toUriString();
+
+            String responseJson = webClient.get()
+                    .uri(uri)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(String.class)
+                    .block();
+
+            return objectMapper.readValue(responseJson, KftcAccountRealNameResponse.class);
+        } catch (Exception e) {
+            log.error("KFTC real-name request failed", e);
+            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED);
+        }
+    }
+
+    private String resolveBankTranId(String bankTranId) {
+        if (bankTranId != null && !bankTranId.isBlank()) {
+            return bankTranId;
+        }
+
+        String orgCode = kftcProperties.getUseOrgCode();
+        if (orgCode == null || orgCode.isBlank()) {
+            orgCode = "M202600000";
+        }
+
+        String randomPart = String.format(
+                "%011d",
+                ThreadLocalRandom.current().nextLong(0, 100_000_000_000L)
+        );
+
+        String generated = orgCode + randomPart;
+        return generated.length() > 20 ? generated.substring(0, 20) : generated;
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
@@ -1,24 +1,60 @@
 package pbl2.sub119.backend.bankaccounts.controller;
 
-
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.bankaccounts.docs.BankDocs;
+import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountRequest;
+import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
+import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
 import pbl2.sub119.backend.bankaccounts.service.BankService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/bank")
 @RequiredArgsConstructor
-public class BankController {
+public class BankController implements BankDocs {
 
     private final BankService bankService;
 
+    @Override
     @GetMapping("/callback")
-    public String callback(@RequestParam String code, @RequestParam String scope) {
-        // User 붙으면 변경 (03.14)
-        bankService.registerAccount(1L, code);
-        return "계좌 등록 성공!";
+    public String callback(
+            @Auth final Accessor accessor,
+            @RequestParam String code,
+            @RequestParam String scope
+    ) {
+        bankService.registerAccount(accessor.getUserId(), code);
+        return "Account registration success";
+    }
+
+    @Override
+    @PostMapping("/settlement")
+    public String registerSettlementAccount(
+            @Auth final Accessor accessor,
+            @Valid @RequestBody RegisterSettlementAccountRequest request
+    ) {
+        bankService.registerSettlementAccount(accessor.getUserId(), request);
+        return "Settlement account registration success";
+    }
+
+    @Override
+    @GetMapping("/accounts")
+    public List<BankAccountSummaryResponse> getAccounts(@Auth final Accessor accessor) {
+        return bankService.getAccounts(accessor.getUserId());
+    }
+
+    @Override
+    @GetMapping("/accounts/primary")
+    public PrimaryBankAccountResponse getPrimaryAccount(@Auth final Accessor accessor) {
+        return bankService.getPrimaryAccount(accessor.getUserId());
     }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
@@ -1,0 +1,98 @@
+package pbl2.sub119.backend.bankaccounts.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountRequest;
+import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
+import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
+import pbl2.sub119.backend.common.error.ErrorResponse;
+
+import java.util.List;
+
+@Tag(name = "Bank", description = "계좌 연결/정산계좌 관리 API")
+public interface BankDocs {
+
+    @Operation(
+            summary = "금융결제원 계좌 연결 콜백",
+            description = "OAuth 인가코드(code)를 받아 사용자의 연결 계좌 후보를 저장합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "계좌 연결 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "계좌 연결 요청 실패 (BANK007)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    String callback(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @Parameter(description = "금융결제원 OAuth 인가코드", required = true, example = "AbCdEf123456")
+            @RequestParam String code,
+            @Parameter(description = "동의 범위(scope)", required = true, example = "login inquiry")
+            @RequestParam String scope
+    );
+
+    @Operation(
+            summary = "정산/환불 계좌 등록",
+            description = "연결된 계좌(fintech_use_num)를 기준으로 정산계좌 메타데이터를 저장하고 실명검증 상태를 반영합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정산계좌 등록 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 계좌 검증 실패 (BANK002, BANK004)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "연결 계좌 없음 (BANK001)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "등록/검증 요청 실패 (BANK003, BANK005)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    String registerSettlementAccount(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @Valid @RequestBody RegisterSettlementAccountRequest request
+    );
+
+    @Operation(
+            summary = "연결 계좌 목록 조회",
+            description = "인증 사용자의 연결된 계좌 목록을 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = BankAccountSummaryResponse.class)))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    List<BankAccountSummaryResponse> getAccounts(
+            @Parameter(hidden = true) @Auth Accessor accessor
+    );
+
+    @Operation(
+            summary = "대표 정산계좌 조회",
+            description = "인증 사용자의 대표 정산계좌를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = PrimaryBankAccountResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "대표 계좌 없음 (BANK006)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    PrimaryBankAccountResponse getPrimaryAccount(
+            @Parameter(hidden = true) @Auth Accessor accessor
+    );
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/KftcAccountRealNameResponse.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/KftcAccountRealNameResponse.java
@@ -1,0 +1,27 @@
+package pbl2.sub119.backend.bankaccounts.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KftcAccountRealNameResponse {
+
+    @JsonProperty("rsp_code")
+    private String rspCode;
+
+    @JsonProperty("rsp_message")
+    private String rspMessage;
+
+    @JsonProperty("account_holder_name")
+    private String accountHolderName;
+
+    public boolean isSuccess() {
+        return "A0000".equals(rspCode) || "0000".equals(rspCode);
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/request/RegisterSettlementAccountRequest.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/request/RegisterSettlementAccountRequest.java
@@ -1,0 +1,48 @@
+package pbl2.sub119.backend.bankaccounts.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "정산/환불 계좌 등록 요청")
+public class RegisterSettlementAccountRequest {
+
+    @NotBlank
+    @Schema(description = "금융결제원 계좌 고유번호(fintech_use_num)", example = "199003839057724125249157")
+    private String fintechUseNum;
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9]{2,20}$")
+    @Schema(description = "은행 표준코드", example = "088")
+    private String bankCode;
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9]+$")
+    @Schema(description = "계좌번호(숫자만)", example = "110123456789")
+    private String accountNumber;
+
+    @NotBlank
+    @Schema(description = "예금주명", example = "홍길동")
+    private String accountHolderName;
+
+    @NotBlank
+    @Pattern(regexp = "^[0-9]{8}$")
+    @Schema(description = "예금주 생년월일(yyyyMMdd)", example = "19900101")
+    private String accountHolderBirthDate;
+
+    @NotNull
+    @Schema(description = "계좌 유형", allowableValues = {"WITHDRAWAL", "SETTLEMENT"}, example = "SETTLEMENT")
+    private AccountType accountType;
+
+    @NotNull
+    @Schema(description = "대표 계좌 여부", example = "true")
+    private Boolean isPrimary;
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/BankAccountSummaryResponse.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/BankAccountSummaryResponse.java
@@ -1,0 +1,53 @@
+package pbl2.sub119.backend.bankaccounts.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
+import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "연결된 계좌 요약 응답")
+public class BankAccountSummaryResponse {
+
+    @Schema(description = "계좌 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "금융결제원 계좌 고유번호(fintech_use_num)")
+    private String fintechUseNum;
+
+    @Schema(description = "은행명", example = "신한은행")
+    private String bankName;
+
+    @Schema(description = "계좌 별칭", example = "주계좌")
+    private String accountAlias;
+
+    @Schema(description = "마스킹된 계좌번호", example = "110-***-****")
+    private String accountNumMasked;
+
+    @Schema(description = "계좌 유형", allowableValues = {"WITHDRAWAL", "SETTLEMENT"})
+    private AccountType accountType;
+
+    @Schema(description = "대표 계좌 여부", example = "true")
+    private Boolean isPrimary;
+
+    @Schema(description = "검증 상태", allowableValues = {"PENDING", "VERIFIED", "FAILED"})
+    private VerificationStatus verificationStatus;
+
+    public static BankAccountSummaryResponse from(BankAccount bankAccount) {
+        return new BankAccountSummaryResponse(
+                bankAccount.getId(),
+                bankAccount.getFintechUseNum(),
+                bankAccount.getBankName(),
+                bankAccount.getAccountAlias(),
+                bankAccount.getAccountNumMasked(),
+                bankAccount.getAccountType(),
+                bankAccount.getIsPrimary(),
+                bankAccount.getVerificationStatus()
+        );
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/PrimaryBankAccountResponse.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/PrimaryBankAccountResponse.java
@@ -1,0 +1,53 @@
+package pbl2.sub119.backend.bankaccounts.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
+import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "대표 정산계좌 응답")
+public class PrimaryBankAccountResponse {
+
+    @Schema(description = "계좌 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "금융결제원 계좌 고유번호(fintech_use_num)")
+    private String fintechUseNum;
+
+    @Schema(description = "은행명", example = "신한은행")
+    private String bankName;
+
+    @Schema(description = "계좌 별칭", example = "주계좌")
+    private String accountAlias;
+
+    @Schema(description = "마스킹된 계좌번호", example = "110-***-****")
+    private String accountNumMasked;
+
+    @Schema(description = "계좌 유형", allowableValues = {"WITHDRAWAL", "SETTLEMENT"})
+    private AccountType accountType;
+
+    @Schema(description = "대표 계좌 여부", example = "true")
+    private Boolean isPrimary;
+
+    @Schema(description = "검증 상태", allowableValues = {"PENDING", "VERIFIED", "FAILED"})
+    private VerificationStatus verificationStatus;
+
+    public static PrimaryBankAccountResponse from(BankAccount bankAccount) {
+        return new PrimaryBankAccountResponse(
+                bankAccount.getId(),
+                bankAccount.getFintechUseNum(),
+                bankAccount.getBankName(),
+                bankAccount.getAccountAlias(),
+                bankAccount.getAccountNumMasked(),
+                bankAccount.getAccountType(),
+                bankAccount.getIsPrimary(),
+                bankAccount.getVerificationStatus()
+        );
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/entity/BankAccount.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/entity/BankAccount.java
@@ -1,20 +1,40 @@
 package pbl2.sub119.backend.bankaccounts.entity;
 
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
+import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BankAccount {
-    private Long id;                  // PK
-    private Long userId;              // 사용자 FK
-    private String fintechUseNum;     // 핀테크이용번호
-    private String accessToken;       // OAuth 접근 토큰
-    private String refreshToken;      // OAuth 갱신 토큰
-    private String bankTranId;        // 은행거래고유번호
-    private String bankName;          // 은행명
-    private String accountAlias;      // 계좌 별칭
-    private String accountNumMasked;  // 마스킹된 계좌번호
-    private Long balanceAmt;          // 계좌 잔액
+    private Long id;
+    private Long userId;
+    private String fintechUseNum;
+    private String accessToken;
+    private String refreshToken;
+    private String bankTranId;
+    private String bankName;
+    private String accountAlias;
+    private String accountNumMasked;
+    private Long balanceAmt;
+
+    private String bankCode;
+    private String accountNumber;
+    private String accountHolderName;
+    private String accountHolderBirthDate;
+    private AccountType accountType;
+    private Boolean isPrimary;
+    private VerificationStatus verificationStatus;
+    private LocalDateTime verifiedAt;
+    private LocalDateTime lastVerifiedAt;
+    private String failReason;
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/enums/AccountType.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/enums/AccountType.java
@@ -1,0 +1,9 @@
+package pbl2.sub119.backend.bankaccounts.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계좌 유형")
+public enum AccountType {
+    WITHDRAWAL,
+    SETTLEMENT
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/enums/VerificationStatus.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/enums/VerificationStatus.java
@@ -1,0 +1,10 @@
+package pbl2.sub119.backend.bankaccounts.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계좌 검증 상태")
+public enum VerificationStatus {
+    PENDING,
+    VERIFIED,
+    FAILED
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/mapper/BankMapper.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/mapper/BankMapper.java
@@ -12,6 +12,9 @@ public interface BankMapper {
     int saveBankAccount(BankAccount bankAccount);
 
     List<BankAccount> findByUserId(@Param("userId") Long userId);
+    List<BankAccount> findAllByUserId(@Param("userId") Long userId);
+    BankAccount findPrimaryByUserId(@Param("userId") Long userId);
+    BankAccount findByUserIdAndFintechUseNum(@Param("userId") Long userId, @Param("fintechUseNum") String fintechUseNum);
 
     Optional<BankAccount> findByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
@@ -20,4 +23,12 @@ public interface BankMapper {
     int deleteByIdAndUserId(@Param("id") Long id, @Param("userId") Long userId);
 
     void updateBankAccount(BankAccount bankAccount);
+
+    int clearPrimaryByUserId(@Param("userId") Long userId);
+
+    int updateSettlementAccountMeta(BankAccount bankAccount);
+    int updateVerificationSuccess(@Param("userId") Long userId, @Param("fintechUseNum") String fintechUseNum);
+    int updateVerificationFailure(@Param("userId") Long userId,
+                                  @Param("fintechUseNum") String fintechUseNum,
+                                  @Param("failReason") String failReason);
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
@@ -1,38 +1,47 @@
 package pbl2.sub119.backend.bankaccounts.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.BodyInserters;
-import org.springframework.web.reactive.function.client.WebClient;
-import pbl2.sub119.backend.bankaccounts.config.KftcProperties;
+import pbl2.sub119.backend.bankaccounts.client.KftcApiClient;
+import pbl2.sub119.backend.bankaccounts.dto.KftcAccountRealNameResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcTokenResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcUserInfoResponse;
+import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountRequest;
+import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
+import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
 import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
+import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
 import pbl2.sub119.backend.bankaccounts.mapper.BankMapper;
+import pbl2.sub119.backend.common.exception.BusinessException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_FAILED;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_CONNECTED_ACCOUNT_NOT_FOUND;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_PRIMARY_ACCOUNT_NOT_FOUND;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class BankService {
 
-    private final WebClient webClient;
     private final BankMapper bankMapper;
-    private final KftcProperties kftcProperties;
-    private final ObjectMapper objectMapper;
+    private final KftcApiClient kftcApiClient;
 
     @Transactional
     public void registerAccount(Long userId, String code) {
-        log.info("KFTC 계좌 인증 시작  userId={}", userId);
+        log.info("KFTC account registration started. userId={}", userId);
 
-        KftcTokenResponse tokenResponse = requestToken(code);
-        KftcUserInfoResponse userInfo = requestUserInfo(tokenResponse);
+        KftcTokenResponse tokenResponse = kftcApiClient.requestToken(code);
+        KftcUserInfoResponse userInfo = kftcApiClient.requestUserInfo(tokenResponse);
 
         if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
-            log.warn("KFTC 계좌 목록이 비어있음. userId={}", userId);
+            log.warn("KFTC account list is empty. userId={}", userId);
             return;
         }
 
@@ -61,43 +70,125 @@ public class BankService {
             processedCount++;
         }
 
-        log.info("KFTC 계좌 인증 완료. userId={}, accountCount={}", userId, processedCount);
+        log.info("KFTC account registration completed. userId={}, accountCount={}", userId, processedCount);
     }
 
-    private KftcTokenResponse requestToken(String code) {
-        try {
-            String tokenJson = webClient.post()
-                    .uri(kftcProperties.getBaseUrl() + "/oauth/2.0/token")
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(BodyInserters.fromFormData("code", code)
-                            .with("client_id", kftcProperties.getClientId())
-                            .with("client_secret", kftcProperties.getClientSecret())
-                            .with("redirect_uri", kftcProperties.getRedirectUrl())
-                            .with("grant_type", "authorization_code"))
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
+    @Transactional
+    public void registerSettlementAccount(Long userId, RegisterSettlementAccountRequest request) {
+        BankAccount connectedAccount = bankMapper.findByUserIdAndFintechUseNum(userId, request.getFintechUseNum());
+        if (connectedAccount == null) {
+            throw new BusinessException(BANK_CONNECTED_ACCOUNT_NOT_FOUND);
+        }
 
-            return objectMapper.readValue(tokenJson, KftcTokenResponse.class);
+        LocalDateTime now = LocalDateTime.now();
+        boolean isPrimary = Boolean.TRUE.equals(request.getIsPrimary());
+
+        if (isPrimary) {
+            bankMapper.clearPrimaryByUserId(userId);
+        }
+
+        BankAccount bankAccount = BankAccount.builder()
+                .userId(userId)
+                .fintechUseNum(request.getFintechUseNum())
+                .bankCode(request.getBankCode())
+                .accountNumber(request.getAccountNumber())
+                .accountHolderName(request.getAccountHolderName())
+                .accountHolderBirthDate(request.getAccountHolderBirthDate())
+                .accountType(request.getAccountType())
+                .isPrimary(isPrimary)
+                .verificationStatus(VerificationStatus.PENDING)
+                .verifiedAt(null)
+                .lastVerifiedAt(now)
+                .failReason(null)
+                .updatedAt(now)
+                .build();
+
+        int updated = bankMapper.updateSettlementAccountMeta(bankAccount);
+        if (updated != 1) {
+            throw new BusinessException(BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED);
+        }
+
+        try {
+            KftcAccountRealNameResponse realNameResponse = kftcApiClient.requestAccountRealName(
+                    connectedAccount.getAccessToken(),
+                    request.getBankCode(),
+                    request.getAccountNumber(),
+                    request.getAccountHolderBirthDate(),
+                    connectedAccount.getBankTranId()
+            );
+
+            boolean nameMatched = normalizeName(request.getAccountHolderName())
+                    .equals(normalizeName(realNameResponse.getAccountHolderName()));
+            boolean verified = realNameResponse.isSuccess() && nameMatched;
+
+            if (verified) {
+                bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
+                log.info("Settlement account verified. userId={}, fintechUseNum={}", userId, request.getFintechUseNum());
+                return;
+            }
+
+            String failReason = realNameResponse.getRspMessage();
+            if (!nameMatched) {
+                failReason = "예금주명이 일치하지 않습니다.";
+            }
+
+            bankMapper.updateVerificationFailure(
+                    userId,
+                    request.getFintechUseNum(),
+                    trimFailReason(failReason)
+            );
+
+            log.warn("Settlement account verification failed. userId={}, fintechUseNum={}",
+                    userId, request.getFintechUseNum());
+
+            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_FAILED);
+
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED) {
+                bankMapper.updateVerificationFailure(
+                        userId,
+                        request.getFintechUseNum(),
+                        trimFailReason(e.getErrorCode().getMessage())
+                );
+            }
+            throw e;
         } catch (Exception e) {
-            log.error("KFTC 토큰 요청 실패", e);
-            throw new RuntimeException("오픈뱅킹 토큰 요청 실패", e);
+            bankMapper.updateVerificationFailure(
+                    userId,
+                    request.getFintechUseNum(),
+                    trimFailReason(e.getMessage())
+            );
+            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED);
         }
     }
 
-    private KftcUserInfoResponse requestUserInfo(KftcTokenResponse tokenResponse) {
-        try {
-            String userJson = webClient.get()
-                    .uri(kftcProperties.getBaseUrl() + "/v2.0/user/me?user_seq_no=" + tokenResponse.getUserSeqNo())
-                    .header("Authorization", "Bearer " + tokenResponse.getAccessToken())
-                    .retrieve()
-                    .bodyToMono(String.class)
-                    .block();
+    @Transactional(readOnly = true)
+    public List<BankAccountSummaryResponse> getAccounts(Long userId) {
+        return bankMapper.findAllByUserId(userId).stream()
+                .map(BankAccountSummaryResponse::from)
+                .toList();
+    }
 
-            return objectMapper.readValue(userJson, KftcUserInfoResponse.class);
-        } catch (Exception e) {
-            log.error("KFTC 사용자 정보 조회 실패", e);
-            throw new RuntimeException("오픈뱅킹 사용자 정보 조회 실패", e);
+    @Transactional(readOnly = true)
+    public PrimaryBankAccountResponse getPrimaryAccount(Long userId) {
+        BankAccount primary = bankMapper.findPrimaryByUserId(userId);
+        if (primary == null) {
+            throw new BusinessException(BANK_PRIMARY_ACCOUNT_NOT_FOUND);
         }
+        return PrimaryBankAccountResponse.from(primary);
+    }
+
+    private String normalizeName(String name) {
+        if (name == null) {
+            return "";
+        }
+        return name.replace(" ", "").trim();
+    }
+
+    private String trimFailReason(String failReason) {
+        if (failReason == null || failReason.isBlank()) {
+            return "계좌 검증에 실패했습니다.";
+        }
+        return failReason.length() > 250 ? failReason.substring(0, 250) : failReason;
     }
 }

--- a/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
+++ b/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
@@ -32,7 +32,6 @@ public enum ErrorCode {
     // MAIL
     RECEIVED_MAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "MAIL001", "존재하지 않는 메일입니다."),
 
-
     // Party
     PARTY_INVALID_PRODUCT_ID(HttpStatus.BAD_REQUEST, "PARTY001", "상품 ID는 필수입니다."),
     PARTY_INVALID_CAPACITY(HttpStatus.BAD_REQUEST, "PARTY002", "정원은 2명 이상이어야 합니다."),
@@ -63,8 +62,17 @@ public enum ErrorCode {
     PAYMENT_BILLING_KEY_ISSUE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT001", "빌링키 발급에 실패했습니다."),
     PAYMENT_BILLING_KEY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "PAYMENT002", "이미 등록된 결제 수단이 있습니다."),
     PAYMENT_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT003", "자동결제 실행에 실패했습니다."),
-    PAYMENT_BILLING_EXECUTION_FAILED(HttpStatus.BAD_REQUEST,"PAYMENT_004","자동결제 실행에 실패했습니다."),
+    PAYMENT_BILLING_EXECUTION_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_004", "자동결제 실행에 실패했습니다."),
     PAYMENT_BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT005", "등록된 결제 수단이 없습니다."),
+
+    // Bank
+    BANK_CONNECTED_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "BANK001", "연결된 계좌를 찾을 수 없습니다."),
+    BANK_INVALID_ACCOUNT_TYPE(HttpStatus.BAD_REQUEST, "BANK002", "유효하지 않은 계좌 유형입니다."),
+    BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BANK003", "정산 계좌 등록에 실패했습니다."),
+    BANK_ACCOUNT_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "BANK004", "계좌 실명 검증에 실패했습니다."),
+    BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BANK005", "계좌 실명 검증 요청에 실패했습니다."),
+    BANK_PRIMARY_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "BANK006", "대표 정산 계좌가 없습니다."),
+    BANK_ACCOUNT_CONNECT_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BANK007", "계좌 연결 요청에 실패했습니다."),
 
     // Party Operation
     PARTY_OPERATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY023", "파티 운영 정보가 존재하지 않습니다."),
@@ -77,7 +85,6 @@ public enum ErrorCode {
     PARTY_OPERATION_RESET_REQUIRED(HttpStatus.BAD_REQUEST, "PARTY030", "운영 재설정이 필요한 상태입니다."),
     PARTY_OPERATION_NOT_READABLE(HttpStatus.BAD_REQUEST, "PARTY031", "현재 상태에서는 운영 정보를 조회할 수 없습니다."),
     PARTY_OPERATION_PASSWORD_DECRYPT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "PARTY032", "공유 계정 비밀번호를 불러오는 중 오류가 발생했습니다.");
-
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/mapper/bankAccounts/BankAccountMapper.xml
+++ b/src/main/resources/mapper/bankAccounts/BankAccountMapper.xml
@@ -13,6 +13,17 @@
         <result property="accountAlias" column="account_alias"/>
         <result property="accountNumMasked" column="account_num_masked"/>
         <result property="balanceAmt" column="balance_amt"/>
+        <result property="bankCode" column="bank_code"/>
+        <result property="accountNumber" column="account_number"/>
+        <result property="accountHolderName" column="account_holder_name"/>
+        <result property="accountHolderBirthDate" column="account_holder_birth_date"/>
+        <result property="accountType" column="account_type"/>
+        <result property="isPrimary" column="is_primary"/>
+        <result property="verificationStatus" column="verification_status"/>
+        <result property="verifiedAt" column="verified_at"/>
+        <result property="lastVerifiedAt" column="last_verified_at"/>
+        <result property="failReason" column="fail_reason"/>
+        <result property="updatedAt" column="updated_at"/>
     </resultMap>
 
     <insert id="saveBankAccount"
@@ -22,15 +33,28 @@
             user_id, fintech_use_num, access_token, refresh_token,
             bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt
         ) VALUES (
-                     #{userId}, #{fintechUseNum}, #{accessToken}, #{refreshToken},
-                     #{bankTranId}, #{bankName}, #{accountAlias}, #{accountNumMasked}, COALESCE(#{balanceAmt}, 0)
-                 )
+            #{userId}, #{fintechUseNum}, #{accessToken}, #{refreshToken},
+            #{bankTranId}, #{bankName}, #{accountAlias}, #{accountNumMasked}, COALESCE(#{balanceAmt}, 0)
+        )
     </insert>
+
+    <select id="findAllByUserId" resultMap="BankAccountMap">
+        SELECT
+            id, user_id, fintech_use_num, access_token, refresh_token,
+            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt,
+            bank_code, account_number, account_holder_name, account_holder_birth_date,
+            account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
+        FROM bank_accounts
+        WHERE user_id = #{userId}
+        ORDER BY id DESC
+    </select>
 
     <select id="findByUserId" resultMap="BankAccountMap">
         SELECT
             id, user_id, fintech_use_num, access_token, refresh_token,
-            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt
+            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt,
+            bank_code, account_number, account_holder_name, account_holder_birth_date,
+            account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
         FROM bank_accounts
         WHERE user_id = #{userId}
         ORDER BY id DESC
@@ -39,10 +63,37 @@
     <select id="findByIdAndUserId" resultMap="BankAccountMap">
         SELECT
             id, user_id, fintech_use_num, access_token, refresh_token,
-            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt
+            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt,
+            bank_code, account_number, account_holder_name, account_holder_birth_date,
+            account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
         FROM bank_accounts
         WHERE id = #{id} AND user_id = #{userId}
-            LIMIT 1
+        LIMIT 1
+    </select>
+
+    <select id="findPrimaryByUserId" resultMap="BankAccountMap">
+        SELECT
+            id, user_id, fintech_use_num, access_token, refresh_token,
+            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt,
+            bank_code, account_number, account_holder_name, account_holder_birth_date,
+            account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
+        FROM bank_accounts
+        WHERE user_id = #{userId}
+          AND is_primary = TRUE
+        ORDER BY id DESC
+        LIMIT 1
+    </select>
+
+    <select id="findByUserIdAndFintechUseNum" resultMap="BankAccountMap">
+        SELECT
+            id, user_id, fintech_use_num, access_token, refresh_token,
+            bank_tran_id, bank_name, account_alias, account_num_masked, balance_amt,
+            bank_code, account_number, account_holder_name, account_holder_birth_date,
+            account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
+        FROM bank_accounts
+        WHERE user_id = #{userId}
+          AND fintech_use_num = #{fintechUseNum}
+        LIMIT 1
     </select>
 
     <select id="existsByUserIdAndFintechUseNum" resultType="boolean">
@@ -65,7 +116,59 @@
             bank_name = #{bankName},
             account_alias = #{accountAlias},
             account_num_masked = #{accountNumMasked},
-            balance_amt = COALESCE(#{balanceAmt}, 0)
+            balance_amt = COALESCE(#{balanceAmt}, 0),
+            updated_at = NOW()
+        WHERE user_id = #{userId}
+          AND fintech_use_num = #{fintechUseNum}
+    </update>
+
+    <update id="clearPrimaryByUserId">
+        UPDATE bank_accounts
+        SET is_primary = FALSE,
+            updated_at = NOW()
+        WHERE user_id = #{userId}
+          AND is_primary = TRUE
+    </update>
+
+    <update id="updateSettlementAccountMeta"
+            parameterType="pbl2.sub119.backend.bankaccounts.entity.BankAccount">
+        UPDATE bank_accounts
+        SET
+            bank_code = #{bankCode},
+            account_number = #{accountNumber},
+            account_holder_name = #{accountHolderName},
+            account_holder_birth_date = #{accountHolderBirthDate},
+            account_type = #{accountType},
+            is_primary = #{isPrimary},
+            verification_status = #{verificationStatus},
+            verified_at = #{verifiedAt},
+            last_verified_at = #{lastVerifiedAt},
+            fail_reason = #{failReason},
+            updated_at = #{updatedAt}
+        WHERE user_id = #{userId}
+          AND fintech_use_num = #{fintechUseNum}
+    </update>
+
+    <update id="updateVerificationSuccess">
+        UPDATE bank_accounts
+        SET
+            verification_status = 'VERIFIED',
+            verified_at = NOW(),
+            last_verified_at = NOW(),
+            fail_reason = NULL,
+            updated_at = NOW()
+        WHERE user_id = #{userId}
+          AND fintech_use_num = #{fintechUseNum}
+    </update>
+
+    <update id="updateVerificationFailure">
+        UPDATE bank_accounts
+        SET
+            verification_status = 'FAILED',
+            verified_at = NULL,
+            last_verified_at = NOW(),
+            fail_reason = #{failReason},
+            updated_at = NOW()
         WHERE user_id = #{userId}
           AND fintech_use_num = #{fintechUseNum}
     </update>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -5,11 +5,13 @@ CREATE TABLE test (
     amount BIGINT
 );
 
---bankAccount (2026.01.26 / kyh)
+--bankAccount (2026.04.09 / kyh)
+DROP TABLE IF EXISTS bank_accounts;
+
 CREATE TABLE IF NOT EXISTS bank_accounts (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT NOT NULL,
-    fintech_use_num VARCHAR(24) NOT NULL,
+                                             id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                             user_id BIGINT NOT NULL,
+                                             fintech_use_num VARCHAR(24) NOT NULL,
     access_token VARCHAR(1000) NOT NULL,
     refresh_token VARCHAR(1000) NOT NULL,
     bank_tran_id VARCHAR(20),
@@ -17,8 +19,26 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
     account_alias VARCHAR(100),
     account_num_masked VARCHAR(20),
     balance_amt BIGINT DEFAULT 0,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+
+    bank_code VARCHAR(10),
+    account_number VARCHAR(50),
+    account_holder_name VARCHAR(100),
+    account_holder_birth_date CHAR(8),
+    account_type VARCHAR(20),
+    is_primary BOOLEAN NOT NULL DEFAULT FALSE,
+    verification_status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    verified_at TIMESTAMP NULL,
+    last_verified_at TIMESTAMP NULL,
+    fail_reason VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+CREATE UNIQUE INDEX IF NOT EXISTS uk_bank_accounts_user_fintech
+    ON bank_accounts(user_id, fintech_use_num);
+
+CREATE INDEX IF NOT EXISTS idx_bank_accounts_user_primary
+    ON bank_accounts(user_id, is_primary);
 
 CREATE UNIQUE INDEX IF NOT EXISTS uk_bank_accounts_user_fintech
     ON bank_accounts(user_id, fintech_use_num);


### PR DESCRIPTION
## 작업 배경
금융결제원 오픈뱅킹 연동 테스트 코드를 기반으로,
우리 플랫폼 내부에서 파티장이 환불/정산받을 계좌를 등록·조회할 수 있도록 bankaccounts 기능을 정리했다.

기존에는
- 금융결제원 외부 API 호출부와 내부 저장 로직이 한 서비스에 섞여 있었고
- `userId=1L` 하드코딩이 남아 있었으며
- 정산계좌 메타데이터 저장/조회 API가 부족했고
- bank 관련 오류코드와 Swagger 문서화도 미흡한 상태였다.

이번 PR에서는 위 부분을 중심으로 bankaccounts 기능을 실제 사용 가능한 수준으로 정리했다.

---

## 주요 변경사항

### 1. 금융결제원 외부 호출부 분리
- `BankService` 내부에 있던 금융결제원 API 호출 로직을 `KftcApiClient`로 분리
- 분리 대상
  - OAuth 토큰 발급 요청
  - 사용자 계좌 목록 조회 요청
  - 계좌 실명조회 요청

### 2. 연결 계좌 저장 흐름 정리
- 금융결제원 callback 이후 연결된 계좌 후보를 `bank_accounts`에 저장
- callback 저장 시에는 실제로 아는 컬럼만 insert 하도록 수정
- 기존 callback 흐름이 신규 메타데이터 컬럼 때문에 깨지지 않도록 안정화

### 3. 정산/환불 계좌 등록 기능 추가
- `POST /api/v1/bank/settlement` 추가
- 연결된 계좌(`fintech_use_num`)를 기준으로 정산계좌 메타데이터 저장
- 저장 대상 메타데이터
  - `bankCode`
  - `accountNumber`
  - `accountHolderName`
  - `accountHolderBirthDate`
  - `accountType`
  - `isPrimary`
  - `verificationStatus`
  - `verifiedAt`
  - `lastVerifiedAt`
  - `failReason`
  - `updatedAt`

### 4. 대표 계좌 처리
- 대표 계좌 등록 시 기존 대표 계좌 `isPrimary=false` 처리
- 사용자 기준 대표 정산계좌 1건 유지하도록 반영

### 5. 실명조회 기반 검증 상태 반영
- 계좌 등록 후 금융결제원 계좌 실명조회 수행
- 성공 시
  - `verificationStatus = VERIFIED`
  - `verifiedAt`, `lastVerifiedAt` 갱신
  - `failReason = null`
- 실패 시
  - `verificationStatus = FAILED`
  - `lastVerifiedAt` 갱신
  - `failReason` 저장

### 6. 조회 API 추가
- `GET /api/v1/bank/accounts`
  - 인증 사용자의 연결 계좌 목록 조회
- `GET /api/v1/bank/accounts/primary`
  - 인증 사용자의 대표 정산계좌 조회

### 7. 인증 사용자 기준으로 동작하도록 수정
- 기존 `userId=1L` 하드코딩 제거
- 프로젝트 기존 인증 방식에 맞춰 `@Auth Accessor` 사용
- bank API가 로그인 사용자 기준으로 동작하도록 변경

### 8. enum 도입
- 문자열 상수로 관리하던 값들을 bankaccounts 내부 enum으로 분리
- 추가 enum
  - `AccountType`
    - `WITHDRAWAL`
    - `SETTLEMENT`
  - `VerificationStatus`
    - `PENDING`
    - `VERIFIED`
    - `FAILED`

### 9. Swagger 문서화 정리
- controller와 docs 분리
- bank API 문서 전용 docs 인터페이스 추가
- 각 API별 summary/description/응답 코드 문서화
- request/response DTO에 schema 설명 추가
- `@Auth Accessor`는 Swagger에 노출되지 않도록 처리

### 10. 공통 오류코드 적용
- bank 관련 오류를 공통 `ErrorCode`에서 관리하도록 정리
- bank 전용 오류코드 추가
  - `BANK001` 연결 계좌 없음
  - `BANK002` 잘못된 계좌 유형
  - `BANK003` 정산 계좌 등록 실패
  - `BANK004` 계좌 실명 검증 실패
  - `BANK005` 계좌 실명 검증 요청 실패
  - `BANK006` 대표 정산 계좌 없음
  - `BANK007` 계좌 연결 요청 실패
- bank 로직에서 `BusinessException + ErrorCode` 방식 사용

---

## DB 변경사항
`bank_accounts` 테이블에 아래 컬럼 추가 필요

- `bank_code`
- `account_number`
- `account_holder_name`
- `account_holder_birth_date`
- `account_type`
- `is_primary`
- `verification_status`
- `verified_at`
- `last_verified_at`
- `fail_reason`
- `updated_at`

로컬 H2에서는 `bank_accounts` 스키마를 최신 기준으로 갱신해서 사용 중

---

## API 목록

### 1. GET `/api/v1/bank/callback`
- 금융결제원 OAuth callback 처리
- 연결 계좌 후보 저장

### 2. POST `/api/v1/bank/settlement`
- 정산/환불 계좌 등록
- 실명조회 결과 반영

### 3. GET `/api/v1/bank/accounts`
- 연결 계좌 목록 조회

### 4. GET `/api/v1/bank/accounts/primary`
- 대표 정산계좌 조회

---

## 테스트 내용
- [x] 금융결제원 callback 이후 연결 계좌 저장 확인
- [x] `bank_accounts` 스키마 최신화 후 API 500 오류 해소 확인
- [x] 정산계좌 등록 API 동작 확인
- [x] 대표 계좌 조회 API 동작 확인
- [x] 연결 계좌 목록 조회 API 동작 확인
- [x] Swagger 문서 노출 확인
- [x] compileJava 통과 확인

---

## 확인 필요 / 후속 작업
- 금융결제원 callback에 대한 인증 처리 정책 재검토 필요
- 계좌 실명조회 API 호출 스펙 정밀 점검 필요
- `account_number`, token 저장 정책은 운영 전 보안 관점에서 추가 검토 필요
- bankaccounts enum 적용 이후 MyBatis enum 매핑 이슈 여부 추가 확인 필요
---

## 리뷰 포인트
1. bankaccounts 도메인 범위에서 enum 분리 방식이 적절한지
2. `@Auth Accessor` 적용 방식이 기존 인증 흐름과 잘 맞는지
3. 대표 계좌 처리 정책(`isPrimary`)이 현재 요구사항에 맞는지
4. 실명조회 실패 시 메타데이터는 저장하고 상태만 FAILED 처리하는 정책이 적절한지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 정산계좌 등록 및 관리 기능 추가
  * 은행 계좌 실명 인증 기능 추가
  * 대표 정산계좌 조회 기능 추가
  * 사용자 계좌 목록 조회 기능 추가
  * 계좌 검증 상태 추적 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->