### PR TITLE
[Payment] 반복결제 상태 반영/과금/정산 기준 정합성 개선

### DIFF
--- a/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
+++ b/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
@@ -64,6 +64,8 @@ public enum ErrorCode {
     PAYMENT_CHARGE_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT003", "자동결제 실행에 실패했습니다."),
     PAYMENT_BILLING_EXECUTION_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_004", "자동결제 실행에 실패했습니다."),
     PAYMENT_BILLING_KEY_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT005", "등록된 결제 수단이 없습니다."),
+    PAYMENT_INVALID_BILLING_REQUEST(HttpStatus.BAD_REQUEST,"PAYMENT006", "유효하지 않은 자동결제 요청입니다."),
+    PAYMENT_INVALID_IDEMPOTENCY_KEY(HttpStatus.BAD_REQUEST,"PAYMENT007", "유효하지 않은 멱등 키입니다."),
 
     // Bank
     BANK_CONNECTED_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "BANK001", "연결된 계좌를 찾을 수 없습니다."),

--- a/src/main/java/pbl2/sub119/backend/party/mapper/PartyMemberMapper.java
+++ b/src/main/java/pbl2/sub119/backend/party/mapper/PartyMemberMapper.java
@@ -36,10 +36,14 @@ public interface PartyMemberMapper {
 
     int countOccupiedMembers(@Param("partyId") Long partyId);
 
+    int countRecurringBillableMembers(@Param("partyId") Long partyId);
+
     int updateLeaveReserved(
             @Param("partyId") Long partyId,
             @Param("userId") Long userId
     );
+
+
 
     int clearLeaveReserved(
             @Param("partyId") Long partyId,

--- a/src/main/java/pbl2/sub119/backend/party/service/PartyCycleService.java
+++ b/src/main/java/pbl2/sub119/backend/party/service/PartyCycleService.java
@@ -25,21 +25,22 @@ public class PartyCycleService {
     private final PartyHistoryService partyHistoryService;
     private final PartyOperationCommandService partyOperationCommandService;
 
-    // 결제 성공 후 시작되는 이용 주기 기준으로 파티 상태를 반영
-    @Transactional
-    public void handleCycleStart(Long partyId) {
+    @Transactional(readOnly = true)
+    public int countRecurringBillableMembers(Long partyId) {
+        return partyMemberMapper.countRecurringBillableMembers(partyId);
+    }
 
+    @Transactional
+    public void confirmRecurringCycleStart(Long partyId) {
         Party party = partyMapper.findByIdForUpdate(partyId);
         if (party == null) {
             throw new PartyException(ErrorCode.PARTY_NOT_FOUND);
         }
 
-        // 이번 결제일 기준으로 탈퇴 예정 멤버를 실제 탈퇴 처리
         List<PartyMember> leaveReservedMembers = partyMemberMapper.findLeaveReservedMembers(partyId);
         for (PartyMember member : leaveReservedMembers) {
             partyMemberMapper.updateStatusAndLeftAt(member.getId(), PartyMemberStatus.LEFT);
 
-            // 파티 이력에 탈퇴 반영 기록 저장
             partyHistoryService.saveHistory(
                     partyId,
                     member.getId(),
@@ -49,17 +50,14 @@ public class PartyCycleService {
             );
         }
 
-        // 결원 충원 대기 멤버를 이번 주기부터 실제 이용 가능 상태로 전환
         List<PartyMember> switchWaitingMembers = partyMemberMapper.findSwitchWaitingMembers(partyId);
         for (PartyMember member : switchWaitingMembers) {
             partyMemberMapper.updateStatusAndActivatedAt(member.getId(), PartyMemberStatus.ACTIVE);
         }
 
-        // 결제일 반영 후 실제 점유 인원 수를 다시 계산
         int occupiedCount = partyMemberMapper.countOccupiedMembers(partyId);
         partyMapper.updateCurrentMemberCount(partyId, occupiedCount);
 
-        // 현재 인원 기준으로 모집 상태와 결원 유형 갱신
         if (occupiedCount >= party.getCapacity()) {
             partyMapper.updateRecruitStatus(partyId, RecruitStatus.FULL);
             partyMapper.updateVacancyType(partyId, VacancyType.NONE);
@@ -68,7 +66,11 @@ public class PartyCycleService {
             partyMapper.updateVacancyType(partyId, VacancyType.MEMBER);
         }
 
-        // 주기 시작 후 멤버 변경 결과를 기준으로 운영 상태도 후속 반영
         partyOperationCommandService.handleCycleStart(partyId);
+    }
+
+    @Transactional
+    public void handleCycleStart(Long partyId) {
+        confirmRecurringCycleStart(partyId);
     }
 }

--- a/src/main/java/pbl2/sub119/backend/payment/listener/PaymentExecutionRequestedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/PaymentExecutionRequestedEventListener.java
@@ -4,10 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
-import pbl2.sub119.backend.toss.service.AutoPaymentService;
+import pbl2.sub119.backend.payment.service.AutoPaymentService;
 
 @Slf4j
 @Component

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
@@ -5,8 +5,6 @@ import org.apache.ibatis.annotations.Param;
 import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 
-import java.time.LocalDateTime;
-
 @Mapper
 public interface PartyCycleMapper {
 
@@ -24,12 +22,12 @@ public interface PartyCycleMapper {
 
     PartyCycle findById(@Param("partyCycleId") Long partyCycleId);
 
+    int findNextCycleNo(@Param("partyId") Long partyId);
+
     PartyCycle findByPartyIdAndCycleNo(
             @Param("partyId") Long partyId,
-            @Param("cycleNo") Integer cycleNo
+            @Param("cycleNo") int cycleNo
     );
-
-    int findNextCycleNo(@Param("partyId") Long partyId);
 
     int compareAndUpdateStatus(
             @Param("partyCycleId") Long partyCycleId,
@@ -41,13 +39,14 @@ public interface PartyCycleMapper {
             @Param("partyCycleId") Long partyCycleId,
             @Param("expectedStatus") PartyCycleStatus expectedStatus,
             @Param("newStatus") PartyCycleStatus newStatus,
-            @Param("endAt") LocalDateTime endAt
+            @Param("endAt") java.time.LocalDateTime endAt
     );
-
-    int save(PartyCycle partyCycle);
 
     int updateMemberCountSnapshot(
             @Param("partyCycleId") Long partyCycleId,
-            @Param("memberCountSnapshot") int memberCountSnapshot
+            @Param("memberCountSnapshot") int memberCountSnapshot,
+            @Param("expectedStatus") PartyCycleStatus expectedStatus
     );
+
+    int save(PartyCycle partyCycle);
 }

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
@@ -45,4 +45,9 @@ public interface PartyCycleMapper {
     );
 
     int save(PartyCycle partyCycle);
+
+    int updateMemberCountSnapshot(
+            @Param("partyCycleId") Long partyCycleId,
+            @Param("memberCountSnapshot") int memberCountSnapshot
+    );
 }

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/PaymentExecutionQueryMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/PaymentExecutionQueryMapper.java
@@ -18,11 +18,23 @@ public interface PaymentExecutionQueryMapper {
             @Param("memberStatus") PartyMemberStatus memberStatus
     );
 
+    int countRecurringBillableMembers(
+            @Param("partyId") Long partyId,
+            @Param("memberRole") PartyRole memberRole
+    );
+
     List<PaymentChargeTarget> findChargeTargets(
             @Param("partyId") Long partyId,
             @Param("partyCycleId") Long partyCycleId,
             @Param("memberRole") PartyRole memberRole,
             @Param("memberStatus") PartyMemberStatus memberStatus,
+            @Param("billingKeyStatus") BillingKeyStatus billingKeyStatus
+    );
+
+    List<PaymentChargeTarget> findRecurringChargeTargets(
+            @Param("partyId") Long partyId,
+            @Param("partyCycleId") Long partyCycleId,
+            @Param("memberRole") PartyRole memberRole,
             @Param("billingKeyStatus") BillingKeyStatus billingKeyStatus
     );
 }

--- a/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
@@ -144,7 +144,16 @@ public class AutoPaymentService {
 
     private void refreshRecurringSnapshot(Long partyId, Long partyCycleId) {
         int billableMemberCount = partyCycleService.countRecurringBillableMembers(partyId);
-        partyCycleMapper.updateMemberCountSnapshot(partyCycleId, billableMemberCount);
+
+        int updated = partyCycleMapper.updateMemberCountSnapshot(
+                partyCycleId,
+                billableMemberCount,
+                PartyCycleStatus.PROCESSING
+        );
+
+        if (updated != 1) {
+            throw new IllegalStateException("party_cycle snapshot 갱신 실패. partyCycleId=" + partyCycleId);
+        }
 
         log.info("반복회차 snapshot 재동기화 완료. partyId={}, partyCycleId={}, memberCountSnapshot={}",
                 partyId, partyCycleId, billableMemberCount);

--- a/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
@@ -1,5 +1,6 @@
-package pbl2.sub119.backend.toss.service;
+package pbl2.sub119.backend.payment.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -15,6 +16,7 @@ import pbl2.sub119.backend.party.enumerated.PartyMemberStatus;
 import pbl2.sub119.backend.party.enumerated.PartyRole;
 import pbl2.sub119.backend.party.mapper.PartyMapper;
 import pbl2.sub119.backend.party.mapper.PartyMemberMapper;
+import pbl2.sub119.backend.party.service.PartyCycleService;
 import pbl2.sub119.backend.party.service.PartyHistoryService;
 import pbl2.sub119.backend.payment.dto.PaymentChargeTarget;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
@@ -23,9 +25,6 @@ import pbl2.sub119.backend.payment.mapper.PaymentExecutionQueryMapper;
 import pbl2.sub119.backend.settlement.event.SettlementRequestedEvent;
 import pbl2.sub119.backend.toss.client.TossPaymentClient;
 import pbl2.sub119.backend.toss.dto.request.TossBillingPaymentRequest;
-
-import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -39,6 +38,7 @@ public class AutoPaymentService {
     private final PartyHistoryService partyHistoryService;
     private final TossPaymentClient tossPaymentClient;
     private final ApplicationEventPublisher eventPublisher;
+    private final PartyCycleService partyCycleService;
 
     @Transactional
     public void execute(Long partyId, Long partyCycleId) {
@@ -47,40 +47,30 @@ public class AutoPaymentService {
             return;
         }
 
-        int claimed = partyCycleMapper.compareAndUpdateStatus(
-                partyCycleId,
-                PartyCycleStatus.PAYMENT_PENDING,
-                PartyCycleStatus.PROCESSING
-        );
-        if (claimed != 1) {
+        if (!claimCycle(partyCycleId)) {
             log.info("자동결제 선점 실패 또는 이미 처리 중. partyId={}, partyCycleId={}", partyId, partyCycleId);
             return;
         }
 
         partyMapper.updateOperationStatus(partyId, OperationStatus.ACTIVE);
 
-        PartyMemberStatus targetMemberStatus = resolveTargetMemberStatus(cycle);
+        if (cycle.getCycleNo() > 1) {
+            // 반복회차 정책:
+            // 1) 상태변이 먼저
+            // 2) 상태변이 후 ACTIVE MEMBER 수로 현재 cycle snapshot 재동기화
+            // 3) 그 다음 ACTIVE MEMBER만 결제
+            partyCycleService.confirmRecurringCycleStart(partyId);
+            refreshRecurringSnapshot(partyId, partyCycleId);
+        }
 
-        int expectedMemberCount = paymentExecutionQueryMapper.countMembersByStatus(
-                partyId,
-                PartyRole.MEMBER,
-                targetMemberStatus
-        );
-
-        List<PaymentChargeTarget> targets = paymentExecutionQueryMapper.findChargeTargets(
-                partyId,
-                partyCycleId,
-                PartyRole.MEMBER,
-                targetMemberStatus,
-                BillingKeyStatus.ACTIVE
-        );
-
-        if (expectedMemberCount == 0 || targets.size() != expectedMemberCount) {
-            failCycle(partyId, partyCycleId, null, 0L, "INVALID_CHARGE_TARGET_COUNT");
+        PaymentTargets paymentTargets = resolvePaymentTargets(partyId, partyCycleId, cycle);
+        if (paymentTargets.expectedMemberCount() == 0
+                || paymentTargets.targets().size() != paymentTargets.expectedMemberCount()) {
+            failCycle(cycle, partyId, partyCycleId, null, 0L, "INVALID_CHARGE_TARGET_COUNT");
             return;
         }
 
-        for (PaymentChargeTarget target : targets) {
+        for (PaymentChargeTarget target : paymentTargets.targets()) {
             try {
                 tossPaymentClient.executeBillingPayment(
                         target.getBillingKey(),
@@ -89,10 +79,11 @@ public class AutoPaymentService {
                                 target.getAmount(),
                                 createOrderId(target),
                                 "Submate 파티 이용료"
-                        )
+                        ),
+                        createIdempotencyKey(target)
                 );
 
-                if (targetMemberStatus == PartyMemberStatus.PENDING) {
+                if (paymentTargets.targetMemberStatus() == PartyMemberStatus.PENDING) {
                     partyMemberMapper.updateStatusAndActivatedAt(
                             target.getMemberId(),
                             PartyMemberStatus.ACTIVE
@@ -112,6 +103,7 @@ public class AutoPaymentService {
                         partyId, partyCycleId, target.getMemberId(), target.getUserId(), e);
 
                 failCycle(
+                        cycle,
                         partyId,
                         partyCycleId,
                         target.getMemberId(),
@@ -133,6 +125,10 @@ public class AutoPaymentService {
 
         closePreviousCycleIfExists(cycle);
 
+        if (cycle.getCycleNo() == 1) {
+            partyCycleService.handleCycleStart(partyId);
+        }
+
         partyMapper.updateOperationStatus(partyId, OperationStatus.ACTIVE);
 
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
@@ -146,11 +142,61 @@ public class AutoPaymentService {
         log.info("자동결제 전원 성공. partyId={}, partyCycleId={}", partyId, partyCycleId);
     }
 
-    private PartyMemberStatus resolveTargetMemberStatus(PartyCycle cycle) {
-        if (cycle.getCycleNo() == 1) {
-            return PartyMemberStatus.PENDING;
+    private void refreshRecurringSnapshot(Long partyId, Long partyCycleId) {
+        int billableMemberCount = partyCycleService.countRecurringBillableMembers(partyId);
+        partyCycleMapper.updateMemberCountSnapshot(partyCycleId, billableMemberCount);
+
+        log.info("반복회차 snapshot 재동기화 완료. partyId={}, partyCycleId={}, memberCountSnapshot={}",
+                partyId, partyCycleId, billableMemberCount);
+    }
+
+    private boolean claimCycle(Long partyCycleId) {
+        int claimed = partyCycleMapper.compareAndUpdateStatus(
+                partyCycleId,
+                PartyCycleStatus.PAYMENT_PENDING,
+                PartyCycleStatus.PROCESSING
+        );
+        if (claimed == 1) {
+            return true;
         }
-        return PartyMemberStatus.ACTIVE;
+
+        return partyCycleMapper.compareAndUpdateStatus(
+                partyCycleId,
+                PartyCycleStatus.FAILED,
+                PartyCycleStatus.PROCESSING
+        ) == 1;
+    }
+
+    private PaymentTargets resolvePaymentTargets(Long partyId, Long partyCycleId, PartyCycle cycle) {
+        if (cycle.getCycleNo() == 1) {
+            PartyMemberStatus targetMemberStatus = PartyMemberStatus.PENDING;
+            int expectedMemberCount = paymentExecutionQueryMapper.countMembersByStatus(
+                    partyId,
+                    PartyRole.MEMBER,
+                    targetMemberStatus
+            );
+            List<PaymentChargeTarget> targets = paymentExecutionQueryMapper.findChargeTargets(
+                    partyId,
+                    partyCycleId,
+                    PartyRole.MEMBER,
+                    targetMemberStatus,
+                    BillingKeyStatus.ACTIVE
+            );
+            return new PaymentTargets(targetMemberStatus, expectedMemberCount, targets);
+        }
+
+        // 반복회차는 상태변이 이후 ACTIVE인 MEMBER만 결제 대상으로 조회한다.
+        int expectedMemberCount = paymentExecutionQueryMapper.countRecurringBillableMembers(
+                partyId,
+                PartyRole.MEMBER
+        );
+        List<PaymentChargeTarget> targets = paymentExecutionQueryMapper.findRecurringChargeTargets(
+                partyId,
+                partyCycleId,
+                PartyRole.MEMBER,
+                BillingKeyStatus.ACTIVE
+        );
+        return new PaymentTargets(null, expectedMemberCount, targets);
     }
 
     private void closePreviousCycleIfExists(PartyCycle currentCycle) {
@@ -175,12 +221,13 @@ public class AutoPaymentService {
         );
 
         if (closed == 1) {
-            log.info("이전 회차 종료 처리 완료. partyId={}, previousCycleId={}, currentCycleId={}",
+            log.info("이전 cycle 종료 처리 완료. partyId={}, previousCycleId={}, currentCycleId={}",
                     currentCycle.getPartyId(), previousCycle.getId(), currentCycle.getId());
         }
     }
 
     private void failCycle(
+            PartyCycle cycle,
             Long partyId,
             Long partyCycleId,
             Long memberId,
@@ -196,7 +243,9 @@ public class AutoPaymentService {
             throw new IllegalStateException("party_cycle FAILED 상태 전이 실패. partyCycleId=" + partyCycleId);
         }
 
-        partyMapper.updateOperationStatus(partyId, OperationStatus.WAITING_START);
+        if (cycle.getCycleNo() == 1) {
+            partyMapper.updateOperationStatus(partyId, OperationStatus.WAITING_START);
+        }
 
         partyHistoryService.saveHistory(
                 partyId,
@@ -210,7 +259,19 @@ public class AutoPaymentService {
     private String createOrderId(PaymentChargeTarget target) {
         return "party-" + target.getPartyId()
                 + "-cycle-" + target.getPartyCycleId()
-                + "-user-" + target.getUserId()
-                + "-" + UUID.randomUUID().toString().substring(0, 8);
+                + "-user-" + target.getUserId();
+    }
+
+    private String createIdempotencyKey(PaymentChargeTarget target) {
+        return "settle:party:" + target.getPartyId()
+                + ":cycle:" + target.getPartyCycleId()
+                + ":user:" + target.getUserId();
+    }
+
+    private record PaymentTargets(
+            PartyMemberStatus targetMemberStatus,
+            int expectedMemberCount,
+            List<PaymentChargeTarget> targets
+    ) {
     }
 }

--- a/src/main/java/pbl2/sub119/backend/payment/service/InitialPaymentCycleService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/InitialPaymentCycleService.java
@@ -39,7 +39,7 @@ public class InitialPaymentCycleService {
                 .endAt(null)
                 .billingDueAt(now)
                 .status(PartyCycleStatus.PAYMENT_PENDING)
-                .memberCountSnapshot(info.getCurrentMemberCount())
+                .memberCountSnapshot(info.getPendingMemberCount())
                 .pricePerMemberSnapshot(info.getPricePerMemberSnapshot())
                 .createdAt(now)
                 .updatedAt(now)

--- a/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
@@ -1,5 +1,7 @@
 package pbl2.sub119.backend.payment.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -8,14 +10,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.party.enumerated.OperationStatus;
+import pbl2.sub119.backend.party.service.PartyCycleService;
 import pbl2.sub119.backend.payment.dto.RecurringPaymentTarget;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
 import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
 import pbl2.sub119.backend.payment.mapper.RecurringPaymentQueryMapper;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -25,6 +25,7 @@ public class RecurringPaymentService {
     private final RecurringPaymentQueryMapper recurringPaymentQueryMapper;
     private final PartyCycleMapper partyCycleMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final PartyCycleService partyCycleService;
 
     @Transactional
     public void processDueCycles() {
@@ -61,6 +62,8 @@ public class RecurringPaymentService {
         }
 
         LocalDateTime now = LocalDateTime.now();
+        // 다음 회차 snapshot은 반복회차 실제 과금 대상과 동일하게 ACTIVE MEMBER 수로 저장한다.
+        int billableMemberCount = partyCycleService.countRecurringBillableMembers(target.getPartyId());
 
         PartyCycle nextCycle = PartyCycle.builder()
                 .partyId(target.getPartyId())
@@ -69,7 +72,7 @@ public class RecurringPaymentService {
                 .endAt(null)
                 .billingDueAt(nextBillingDueAt)
                 .status(PartyCycleStatus.PAYMENT_PENDING)
-                .memberCountSnapshot(target.getMemberCountSnapshot())
+                .memberCountSnapshot(billableMemberCount)
                 .pricePerMemberSnapshot(target.getPricePerMemberSnapshot())
                 .createdAt(now)
                 .updatedAt(now)

--- a/src/main/java/pbl2/sub119/backend/settlement/service/SettlementService.java
+++ b/src/main/java/pbl2/sub119/backend/settlement/service/SettlementService.java
@@ -1,5 +1,6 @@
 package pbl2.sub119.backend.settlement.service;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -14,8 +15,6 @@ import pbl2.sub119.backend.pointWallet.entity.PointWallet;
 import pbl2.sub119.backend.pointWallet.mapper.PointWalletMapper;
 import pbl2.sub119.backend.settlement.entity.Settlement;
 import pbl2.sub119.backend.settlement.mapper.SettlementMapper;
-
-import java.time.LocalDateTime;
 
 @Slf4j
 @Service
@@ -51,7 +50,8 @@ public class SettlementService {
             throw new IllegalStateException("파티가 존재하지 않습니다. partyId=" + partyId);
         }
 
-        int memberCount = cycle.getMemberCountSnapshot() - 1; // host 제외
+        // 정산 인원수는 호스트를 제외한 ACTIVE MEMBER 기준 snapshot 값을 그대로 사용한다.
+        int memberCount = cycle.getMemberCountSnapshot();
         if (memberCount <= 0) {
             log.info("정산 대상 멤버가 없습니다. partyId={}, partyCycleId={}", partyId, partyCycleId);
             return;

--- a/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
@@ -30,7 +30,10 @@ public class TossPaymentClient {
     }
 
     public TossBillingAuthResponse issueBillingKey(TossBillingAuthRequest request) {
+        validateBillingAuthRequest(request);
+
         log.info("토스 빌링키 발급 요청. customerKey={}", request.customerKey());
+
         try {
             return webClient.post()
                     .uri(tossPaymentProperties.getBaseUrl() + "/v1/billing/authorizations/issue")
@@ -41,7 +44,7 @@ public class TossPaymentClient {
                     .bodyToMono(TossBillingAuthResponse.class)
                     .block();
         } catch (WebClientResponseException e) {
-            log.error("토스 빌링키 발급 실패. status={}", e.getStatusCode());
+            log.error("토스 빌링키 발급 실패. status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
             throw new PaymentException(ErrorCode.PAYMENT_BILLING_KEY_ISSUE_FAILED);
         }
     }
@@ -51,6 +54,8 @@ public class TossPaymentClient {
             TossBillingPaymentRequest request,
             String idempotencyKey
     ) {
+        validateBillingPaymentRequest(billingKey, request, idempotencyKey);
+
         log.info("토스 자동결제 요청. orderId={}, amount={}",
                 request.orderId(), request.amount());
 
@@ -65,8 +70,37 @@ public class TossPaymentClient {
                     .bodyToMono(TossBillingPaymentResponse.class)
                     .block();
         } catch (WebClientResponseException e) {
-            log.error("토스 자동결제 실패. status={}", e.getStatusCode());
+            log.error("토스 자동결제 실패. status={}, body={}", e.getStatusCode(), e.getResponseBodyAsString());
             throw new PaymentException(ErrorCode.PAYMENT_BILLING_EXECUTION_FAILED);
         }
+    }
+
+    private void validateBillingAuthRequest(TossBillingAuthRequest request) {
+        if (request == null || isBlank(request.customerKey())) {
+            throw new PaymentException(ErrorCode.PAYMENT_INVALID_BILLING_REQUEST);
+        }
+    }
+
+    private void validateBillingPaymentRequest(
+            String billingKey,
+            TossBillingPaymentRequest request,
+            String idempotencyKey
+    ) {
+        if (isBlank(billingKey)
+                || request == null
+                || isBlank(request.customerKey())
+                || isBlank(request.orderId())
+                || request.amount() == null
+                || request.amount() <= 0) {
+            throw new PaymentException(ErrorCode.PAYMENT_INVALID_BILLING_REQUEST);
+        }
+
+        if (isBlank(idempotencyKey)) {
+            throw new PaymentException(ErrorCode.PAYMENT_INVALID_IDEMPOTENCY_KEY);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
@@ -48,7 +48,8 @@ public class TossPaymentClient {
 
     public TossBillingPaymentResponse executeBillingPayment(
             String billingKey,
-            TossBillingPaymentRequest request
+            TossBillingPaymentRequest request,
+            String idempotencyKey
     ) {
         log.info("토스 자동결제 요청. orderId={}, amount={}",
                 request.orderId(), request.amount());
@@ -57,6 +58,7 @@ public class TossPaymentClient {
             return webClient.post()
                     .uri(tossPaymentProperties.getBaseUrl() + "/v1/billing/" + billingKey)
                     .header(HttpHeaders.AUTHORIZATION, encodeSecretKey())
+                    .header("Idempotency-Key", idempotencyKey)
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(request)
                     .retrieve()

--- a/src/main/resources/mapper/party/PartyMemberMapper.xml
+++ b/src/main/resources/mapper/party/PartyMemberMapper.xml
@@ -150,6 +150,15 @@
           AND status IN ('ACTIVE', 'PENDING', 'LEAVE_RESERVED', 'SWITCH_WAITING')
     </select>
 
+    <!-- 다음 회차 snapshot 수는 반복회차 실제 과금 대상과 동일하게 ACTIVE MEMBER만 사용한다. -->
+    <select id="countRecurringBillableMembers" resultType="int">
+        SELECT COUNT(*)
+        FROM party_member
+        WHERE party_id = #{partyId}
+          AND role = 'MEMBER'
+          AND status = 'ACTIVE'
+    </select>
+
     <update id="updateLeaveReserved">
         UPDATE party_member
         SET

--- a/src/main/resources/mapper/payment/PartyCycleMapper.xml
+++ b/src/main/resources/mapper/payment/PartyCycleMapper.xml
@@ -131,4 +131,11 @@
                  )
     </insert>
 
+    <update id="updateMemberCountSnapshot">
+        UPDATE party_cycle
+        SET member_count_snapshot = #{memberCountSnapshot},
+            updated_at = NOW()
+        WHERE id = #{partyCycleId}
+    </update>
+
 </mapper>

--- a/src/main/resources/mapper/payment/PartyCycleMapper.xml
+++ b/src/main/resources/mapper/payment/PartyCycleMapper.xml
@@ -102,6 +102,14 @@
           AND status = #{expectedStatus}
     </update>
 
+    <update id="updateMemberCountSnapshot">
+        UPDATE party_cycle
+        SET member_count_snapshot = #{memberCountSnapshot},
+            updated_at = NOW()
+        WHERE id = #{partyCycleId}
+          AND status = #{expectedStatus}
+    </update>
+
     <insert id="save"
             parameterType="pbl2.sub119.backend.payment.entity.PartyCycle"
             useGeneratedKeys="true"
@@ -130,12 +138,5 @@
                      #{updatedAt}
                  )
     </insert>
-
-    <update id="updateMemberCountSnapshot">
-        UPDATE party_cycle
-        SET member_count_snapshot = #{memberCountSnapshot},
-            updated_at = NOW()
-        WHERE id = #{partyCycleId}
-    </update>
 
 </mapper>

--- a/src/main/resources/mapper/payment/PaymentExecutionQueryMapper.xml
+++ b/src/main/resources/mapper/payment/PaymentExecutionQueryMapper.xml
@@ -22,6 +22,15 @@
           AND status = #{memberStatus}
     </select>
 
+    <!-- 반복회차 과금 대상은 상태변이 반영 이후 ACTIVE인 MEMBER만 집계한다. -->
+    <select id="countRecurringBillableMembers" resultType="int">
+        SELECT COUNT(1)
+        FROM party_member
+        WHERE party_id = #{partyId}
+          AND role = #{memberRole}
+          AND status = 'ACTIVE'
+    </select>
+
     <select id="findChargeTargets" resultMap="PaymentChargeTargetMap">
         SELECT pm.party_id                  AS party_id,
                pc.id                        AS party_cycle_id,
@@ -39,6 +48,28 @@
           AND pc.id = #{partyCycleId}
           AND pm.role = #{memberRole}
           AND pm.status = #{memberStatus}
+          AND bk.status = #{billingKeyStatus}
+        ORDER BY pm.id ASC
+    </select>
+
+    <!-- 반복회차 과금 조회는 ACTIVE인 MEMBER만 대상으로 하고 LEAVE_RESERVED, SWITCH_WAITING은 제외한다. -->
+    <select id="findRecurringChargeTargets" resultMap="PaymentChargeTargetMap">
+        SELECT pm.party_id                  AS party_id,
+               pc.id                        AS party_cycle_id,
+               pm.id                        AS member_id,
+               pm.user_id                   AS user_id,
+               bk.billing_key               AS billing_key,
+               bk.customer_key              AS customer_key,
+               pc.price_per_member_snapshot AS amount
+        FROM party_member pm
+                 INNER JOIN billing_key bk
+                            ON bk.user_id = pm.user_id
+                 INNER JOIN party_cycle pc
+                            ON pc.party_id = pm.party_id
+        WHERE pm.party_id = #{partyId}
+          AND pc.id = #{partyCycleId}
+          AND pm.role = #{memberRole}
+          AND pm.status = 'ACTIVE'
           AND bk.status = #{billingKeyStatus}
         ORDER BY pm.id ASC
     </select>


### PR DESCRIPTION
## 배경
반복결제 처리 시 회차 시작 상태 반영, 과금 대상, cycle snapshot, settlement 기준이 서로 어긋날 가능성이 있어 정합성 개선이 필요했습니다.


## 주요 변경 사항
-반복회차 상태 반영 정책 정리  
-LEAVE_RESERVED -> LEFT
-SWITCH_WAITING -> ACTIVE
-반복회차 과금 대상 기준을 ACTIVE MEMBER로 통일
-cycle member_count_snapshot 기준을 실제 반복 과금 기준과 통일
-settlement memberCount를 cycle snapshot 기준으로 통일
-deterministic orderId, Idempotency-Key 적용
-반복회차 실패 시 operation_status를 WAITING_START로 내리지 않도록 수정 


## 기대 효과
-반복회차 상태/과금/정산 기준 정합성 확보
-탈퇴 예약 및 교체 대기 시나리오 안정화
-재시도 시 중복과금 위험 완화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반복 청구 대상 멤버 식별 및 계산 기능 추가
  * 반복 청구 대상 조회 및 청구 대상 집합 반환 기능 추가
  * 멤버 수 스냅샷 갱신 기능 추가

* **버그 수정**
  * 결제 요청 검증 강화 및 멱등성 키 검증/헤더 추가로 중복 결제 방지 강화
  * 결제/요청 오류 로깅 개선

* **리팩토링**
  * 결제 주기 시작 처리 흐름 정리 및 반복 결제 흐름 최적화
  * 정산 기준(멤버 수) 계산 로직 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->