### PR TITLE
[bank] 인증 호출부 분리

### DIFF
--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
@@ -2,21 +2,32 @@ package pbl2.sub119.backend.bankaccounts.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 import pbl2.sub119.backend.auth.aop.Auth;
 import pbl2.sub119.backend.auth.entity.Accessor;
-import pbl2.sub119.backend.bankaccounts.docs.BankDocs;
+import pbl2.sub119.backend.bankaccounts.controller.docs.BankDocs;
+import pbl2.sub119.backend.bankaccounts.dto.BankAuthState;
 import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountRequest;
 import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
 import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
+import pbl2.sub119.backend.bankaccounts.service.BankAuthStateStore;
 import pbl2.sub119.backend.bankaccounts.service.BankService;
+import pbl2.sub119.backend.common.exception.BusinessException;
 
+import java.net.URI;
 import java.util.List;
+
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
 
 @RestController
 @RequestMapping("/api/v1/bank")
@@ -24,16 +35,95 @@ import java.util.List;
 public class BankController implements BankDocs {
 
     private final BankService bankService;
+    private final BankAuthStateStore bankAuthStateStore;
+
+    @Value("${app.frontend-base-url}")
+    private String frontendBaseUrl;
+
+    @Value("${kftc.client-id}")
+    private String kftcClientId;
+
+    @Value("${kftc.redirect-url}")
+    private String kftcRedirectUrl;
+
+    @Value("${kftc.base-url}")
+    private String kftcBaseUrl;
+
+    @Override
+    @GetMapping("/authorize")
+    public ResponseEntity<Void> authorize(
+            @Auth final Accessor accessor,
+            @RequestParam Long productId
+    ) {
+        String state = bankAuthStateStore.create(accessor.getUserId(), productId);
+
+        String authorizeUrl = UriComponentsBuilder
+                .fromHttpUrl(kftcBaseUrl + "/oauth/2.0/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", kftcClientId)
+                .queryParam("redirect_uri", kftcRedirectUrl)
+                .queryParam("scope", "login inquiry")
+                .queryParam("state", state)
+                .queryParam("auth_type", "0")
+                .toUriString();
+
+        return redirect(authorizeUrl);
+    }
 
     @Override
     @GetMapping("/callback")
-    public String callback(
-            @Auth final Accessor accessor,
+    public ResponseEntity<Void> callback(
             @RequestParam String code,
-            @RequestParam String scope
+            @RequestParam(required = false) String scope,
+            @RequestParam String state
     ) {
-        bankService.registerAccount(accessor.getUserId(), code);
-        return "Account registration success";
+        BankAuthState authState = bankAuthStateStore.get(state);
+
+        if (authState == null) {
+            String invalidStateUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl)
+                    .path("/party/create/0/host/account-register")
+                    .queryParam("bankAuthSuccess", false)
+                    .queryParam("message", "유효하지 않은 인증 요청입니다.")
+                    .toUriString();
+
+            return redirect(invalidStateUrl);
+        }
+
+        String redirectBaseUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl)
+                .path("/party/create/{productId}/host/account-register")
+                .buildAndExpand(authState.getProductId())
+                .toUriString();
+
+        try {
+            bankService.registerAccount(authState.getUserId(), code);
+            bankAuthStateStore.remove(state);
+
+            String successUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+                    .queryParam("bankAuthSuccess", true)
+                    .toUriString();
+
+            return redirect(successUrl);
+
+        } catch (BusinessException e) {
+            bankAuthStateStore.remove(state);
+
+            String failUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+                    .queryParam("bankAuthSuccess", false)
+                    .queryParam("message", e.getErrorCode().getMessage())
+                    .toUriString();
+
+            return redirect(failUrl);
+
+        } catch (Exception e) {
+            bankAuthStateStore.remove(state);
+
+            String failUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+                    .queryParam("bankAuthSuccess", false)
+                    .queryParam("message", BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED.getMessage())
+                    .toUriString();
+
+            return redirect(failUrl);
+        }
     }
 
     @Override
@@ -56,5 +146,11 @@ public class BankController implements BankDocs {
     @GetMapping("/accounts/primary")
     public PrimaryBankAccountResponse getPrimaryAccount(@Auth final Accessor accessor) {
         return bankService.getPrimaryAccount(accessor.getUserId());
+    }
+
+    private ResponseEntity<Void> redirect(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create(url));
+        return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
     }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
@@ -1,4 +1,4 @@
-package pbl2.sub119.backend.bankaccounts.docs;
+package pbl2.sub119.backend.bankaccounts.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import pbl2.sub119.backend.auth.aop.Auth;
@@ -24,25 +25,40 @@ import java.util.List;
 public interface BankDocs {
 
     @Operation(
-            summary = "금융결제원 계좌 연결 콜백",
-            description = "OAuth 인가코드(code)를 받아 사용자의 연결 계좌 후보를 저장합니다."
+            summary = "금융결제원 계좌 연결 인증 시작",
+            description = "로그인 사용자의 계좌 연결을 위해 금융결제원 authorize URL로 리다이렉트합니다."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "계좌 연결 성공",
-                    content = @Content(schema = @Schema(implementation = String.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "302", description = "금융결제원 authorize URL로 리다이렉트",
+                    content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "계좌 연결 요청 실패 (BANK007)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
-    String callback(
+    ResponseEntity<Void> authorize(
             @Parameter(hidden = true) @Auth Accessor accessor,
+            @Parameter(description = "파티 생성 대상 상품 ID", required = true, example = "1")
+            @RequestParam Long productId
+    );
+
+    @Operation(
+            summary = "금융결제원 계좌 연결 콜백",
+            description = "OAuth 인가코드(code)와 state를 받아 연결 계좌 후보를 저장한 뒤 프론트 계좌등록 페이지로 리다이렉트합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "프론트 계좌등록 페이지로 리다이렉트",
+                    content = @Content),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "계좌 연결 요청 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    ResponseEntity<Void> callback(
             @Parameter(description = "금융결제원 OAuth 인가코드", required = true, example = "AbCdEf123456")
             @RequestParam String code,
-            @Parameter(description = "동의 범위(scope)", required = true, example = "login inquiry")
-            @RequestParam String scope
+            @Parameter(description = "동의 범위(scope)", required = false, example = "login inquiry")
+            @RequestParam(required = false) String scope,
+            @Parameter(description = "인증 요청 식별용 state", required = true, example = "12345678901234567890123456789012")
+            @RequestParam String state
     );
 
     @Operation(

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthState.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthState.java
@@ -1,0 +1,12 @@
+package pbl2.sub119.backend.bankaccounts.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class BankAuthState {
+    private Long userId;
+    private Long productId;
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthStateStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthStateStore.java
@@ -1,0 +1,28 @@
+package pbl2.sub119.backend.bankaccounts.service;
+
+import org.springframework.stereotype.Component;
+import pbl2.sub119.backend.bankaccounts.dto.BankAuthState;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class BankAuthStateStore {
+
+    private final Map<String, BankAuthState> store = new ConcurrentHashMap<>();
+
+    public String create(Long userId, Long productId) {
+        String state = UUID.randomUUID().toString().replace("-", "");
+        store.put(state, new BankAuthState(userId, productId));
+        return state;
+    }
+
+    public BankAuthState get(String state) {
+        return store.get(state);
+    }
+
+    public void remove(String state) {
+        store.remove(state);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,3 +59,6 @@ kftc:
 toss:
   secret-key: ${TOSS_SECRET_KEY}
   base-url : https://api.tosspayments.com
+
+app:
+  frontend-base-url: ${FRONTEND_BASE_URL}


### PR DESCRIPTION
- store는 추후 Redis 붙여서 관리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **신기능**
  * OAuth 스타일의 은행 계좌 인증 플로우를 추가하여 보안이 강화된 계좌 연동 프로세스 구현
  * 상태 기반 검증 메커니즘 도입으로 계좌 등록 중 보안성 향상
  * 오류 발생 시 프론트엔드 페이지로의 리다이렉트 기반 에러 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->