### PR TITLE
[payment/settlement] PartyCycle 결제 금액 수수료 반영 및 정산 수수료 공제 로직 적용

### DIFF
--- a/src/main/java/pbl2/sub119/backend/payment/service/InitialPaymentCycleService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/InitialPaymentCycleService.java
@@ -8,6 +8,7 @@ import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.payment.dto.PartyPaymentReadinessInfo;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
+import pbl2.sub119.backend.payment.policy.FeePolicy;
 
 import java.time.LocalDateTime;
 
@@ -40,7 +41,7 @@ public class InitialPaymentCycleService {
                 .billingDueAt(now)
                 .status(PartyCycleStatus.PAYMENT_PENDING)
                 .memberCountSnapshot(info.getPendingMemberCount())
-                .pricePerMemberSnapshot(info.getPricePerMemberSnapshot())
+                .pricePerMemberSnapshot(Math.toIntExact(info.getPricePerMemberSnapshot() + FeePolicy.MEMBER_FEE))
                 .createdAt(now)
                 .updatedAt(now)
                 .build();

--- a/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
@@ -74,6 +74,7 @@ public class RecurringPaymentService {
                 .billingDueAt(nextBillingDueAt)
                 .status(PartyCycleStatus.PAYMENT_PENDING)
                 .memberCountSnapshot(billableMemberCount)
+                // pricePerMemberSnapshot은 첫 회차에 수수료(FeePolicy.MEMBER_FEE)가 포함된 값으로 저장되며 이후 회차는 그대로 이어받는다.
                 .pricePerMemberSnapshot(target.getPricePerMemberSnapshot())
                 .createdAt(now)
                 .updatedAt(now)

--- a/src/main/java/pbl2/sub119/backend/settlement/entity/Settlement.java
+++ b/src/main/java/pbl2/sub119/backend/settlement/entity/Settlement.java
@@ -19,6 +19,7 @@ public class Settlement {
     private Integer memberCount;
     private Integer unitAmount;
     private Long totalAmount;
+    private Long feeDeducted;
     private SettlementStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/pbl2/sub119/backend/settlement/service/SettlementService.java
+++ b/src/main/java/pbl2/sub119/backend/settlement/service/SettlementService.java
@@ -11,6 +11,7 @@ import pbl2.sub119.backend.party.common.entity.Party;
 import pbl2.sub119.backend.party.common.mapper.PartyMapper;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
+import pbl2.sub119.backend.payment.policy.FeePolicy;
 import pbl2.sub119.backend.pointWallet.entity.PointWallet;
 import pbl2.sub119.backend.pointWallet.mapper.PointWalletMapper;
 import pbl2.sub119.backend.settlement.entity.Settlement;
@@ -58,7 +59,12 @@ public class SettlementService {
         }
 
         int unitAmount = cycle.getPricePerMemberSnapshot();
-        long totalAmount = (long) memberCount * unitAmount;
+        long totalCharged = (long) memberCount * unitAmount;
+
+        // 파티원 수수료 전액 회수 + 파티장 수수료 공제
+        long feeDeducted = (long) memberCount * FeePolicy.MEMBER_FEE + FeePolicy.HOST_FEE;
+        long totalAmount = Math.max(0L, totalCharged - feeDeducted);
+
         LocalDateTime now = LocalDateTime.now();
 
         Settlement settlement = Settlement.builder()
@@ -68,6 +74,7 @@ public class SettlementService {
                 .memberCount(memberCount)
                 .unitAmount(unitAmount)
                 .totalAmount(totalAmount)
+                .feeDeducted(feeDeducted)
                 .status(SettlementStatus.ACCRUED)
                 .createdAt(now)
                 .updatedAt(now)

--- a/src/main/resources/mapper/settlement/SettlementMapper.xml
+++ b/src/main/resources/mapper/settlement/SettlementMapper.xml
@@ -12,6 +12,7 @@
         <result property="memberCount" column="member_count"/>
         <result property="unitAmount" column="unit_amount"/>
         <result property="totalAmount" column="total_amount"/>
+        <result property="feeDeducted" column="fee_deducted"/>
         <result property="status" column="status"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -25,6 +26,7 @@
                member_count,
                unit_amount,
                total_amount,
+               fee_deducted,
                status,
                created_at,
                updated_at
@@ -44,6 +46,7 @@
             member_count,
             unit_amount,
             total_amount,
+            fee_deducted,
             status,
             created_at,
             updated_at
@@ -54,6 +57,7 @@
                      #{memberCount},
                      #{unitAmount},
                      #{totalAmount},
+                     #{feeDeducted},
                      #{status},
                      #{createdAt},
                      #{updatedAt}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -308,6 +308,7 @@ CREATE UNIQUE INDEX uk_party_operation_member_operation_member
     ON party_operation_member(party_operation_id, party_member_id);
 
 -- settlement (2026.04.04 / kyh)
+-- fee_deducted 추가 (2026.04.26 / kyh) : 파티원 수수료 전액 + 파티장 수수료 공제 합산
 CREATE TABLE settlement (
     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     party_id BIGINT NOT NULL,
@@ -316,6 +317,7 @@ CREATE TABLE settlement (
     member_count INT NOT NULL,
     unit_amount INT NOT NULL,
     total_amount BIGINT NOT NULL,
+    fee_deducted BIGINT NOT NULL DEFAULT 0,
     status VARCHAR(30) NOT NULL,
     created_at DATETIME NOT NULL,
     updated_at DATETIME NOT NULL


### PR DESCRIPTION
Summary                                                   
  - PartyCycle 생성 시 pricePerMemberSnapshot에 파티원 수수료(990원)를 포함하여 실제 Toss 청구액에 수수료가 반영되도록 수정
  - 기존 SettlementService가 결제 총액을 그대로 파티장에게 지급하던 버그를 수정, 수수료 공제 후 실제 정산액만 포인트에 적립
  - 수수료 공제 내역을 Settlement.feeDeducted에 기록하여 정산 이력 추적 가능

  변경 파일

  ┌─────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────┐
  │                      파일                       │                           변경 내용                           │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ payment/service/InitialPaymentCycleService.java │ pricePerMemberSnapshot = 상품가 + FeePolicy.MEMBER_FEE        │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ payment/service/RecurringPaymentService.java    │ snapshot 전파 의도 주석 명시 (로직 변경 없음)                 │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ settlement/entity/Settlement.java               │ feeDeducted: Long 필드 추가                                   │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ settlement/service/SettlementService.java       │ 수수료 공제 계산 로직 적용                                    │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ mapper/settlement/SettlementMapper.xml          │ resultMap / select / insert에 fee_deducted 반영               │
  ├─────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ resources/schema.sql                            │ settlement 테이블 fee_deducted BIGINT NOT NULL DEFAULT 0 추가 │
  └─────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────┘

  Before / After

  // [payment] Before — InitialPaymentCycleService
  .pricePerMemberSnapshot(info.getPricePerMemberSnapshot())
  // Toss 청구액 = 상품가만 (수수료 미포함)

  // After
  .pricePerMemberSnapshot(Math.toIntExact(info.getPricePerMemberSnapshot() + FeePolicy.MEMBER_FEE))
  // Toss 청구액 = 상품가 + 990원

  // [settlement] Before — SettlementService
  long totalAmount = (long) memberCount * unitAmount;
  pointWalletMapper.updateBalance(hostUserId, totalAmount);
  // 수수료 공제 없이 전액 지급

  // After
  long feeDeducted = (long) memberCount * FeePolicy.MEMBER_FEE + FeePolicy.HOST_FEE;
  long totalAmount = Math.max(0L, totalCharged - feeDeducted);
  pointWalletMapper.updateBalance(hostUserId, totalAmount);
  // 수수료 공제 후 정산액만 지급

  정산 계산 정책
  결제 총액     = memberCount × (상품가 + 990)
  수수료 공제   = memberCount × 990 + 490
  파티장 정산액 = 결제 총액 - 수수료 공제

  DB 마이그레이션
  ALTER TABLE settlement
      ADD COLUMN fee_deducted BIGINT NOT NULL DEFAULT 0;

  테스트 체크리스트
  - 첫 회차 PartyCycle.pricePerMemberSnapshot = 상품가 + 990 저장 확인
  - 반복 회차 동일 금액 이어받는지 확인
  - settlement.fee_deducted 컬럼에 공제 금액 정상 저장 확인
  - 파티원 3명, 상품가 4500원 기준 → 정산액 = 3 × 5490 - 3 × 990 - 490 = 13,040원 확인
  - 정산액 0 미만 엣지 케이스 방어 동작 확인
