### PR TITLE
feat: 마이페이지 파티 히스토리 조회 API 구현

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/history/controller/PartyHistoryController.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/controller/PartyHistoryController.java
@@ -1,0 +1,29 @@
+package pbl2.sub119.backend.party.history.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.party.history.controller.docs.PartyHistoryDocs;
+import pbl2.sub119.backend.party.history.dto.PartyHistoryResponse;
+import pbl2.sub119.backend.party.history.service.PartyHistoryQueryService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/me/party-history")
+public class PartyHistoryController implements PartyHistoryDocs {
+
+    private final PartyHistoryQueryService partyHistoryQueryService;
+
+    @Override
+    public ResponseEntity<List<PartyHistoryResponse>> getMyPartyHistories(
+            @Auth final Accessor accessor
+    ) {
+        return ResponseEntity.ok(
+                partyHistoryQueryService.getMyPartyHistories(accessor.getUserId())
+        );
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/party/history/controller/docs/PartyHistoryDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/controller/docs/PartyHistoryDocs.java
@@ -1,0 +1,75 @@
+package pbl2.sub119.backend.party.history.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.party.history.dto.PartyHistoryResponse;
+
+@Tag(
+        name = "Party History API",
+        description = "마이페이지 파티 히스토리 API"
+)
+public interface PartyHistoryDocs {
+
+    @Operation(
+            summary = "내 파티 히스토리 조회",
+            description = """
+                    마이페이지에서 사용자가 참여했던 파티 이력을 조회합니다.
+
+                    이 API는 아래 화면에서 사용합니다.
+                    - 마이페이지 > 파티 히스토리
+
+                    조회 기준:
+                    - party_member 기준으로 사용자가 실제 참여했던 파티를 조회합니다.
+                    - 자동 매칭 신청 내역은 포함하지 않습니다.
+
+                    응답 데이터:
+                    - partyId : 파티 PK
+                    - displayPartyId : 화면 표시용 파티 ID
+                    - productId : 상품 ID
+                    - productName : 상품명
+                    - role : 파티 내 역할
+                    - status : 파티 히스토리 상태
+                    - startAt : 이용 시작일
+                    - endAt : 이용 종료일
+
+                    역할(role) 안내:
+                    - HOST : 파티장
+                    - MEMBER : 파티원
+
+                    상태값(status) 안내:
+                    - USING : 이용 중
+                    - ENDED : 종료
+
+                    기간 기준:
+                    - startAt : party_member.service_start_at
+                    - endAt : party_member.service_end_at
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "내 파티 히스토리 조회 성공",
+                            content = @Content(
+                                    array = @ArraySchema(schema = @Schema(implementation = PartyHistoryResponse.class))
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "토큰 없음 또는 유효하지 않은 토큰"
+                    )
+            }
+    )
+    @GetMapping
+    ResponseEntity<List<PartyHistoryResponse>> getMyPartyHistories(
+            @Parameter(hidden = true) @Auth Accessor accessor
+    );
+}

--- a/src/main/java/pbl2/sub119/backend/party/history/dto/PartyHistoryResponse.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/dto/PartyHistoryResponse.java
@@ -1,0 +1,15 @@
+package pbl2.sub119.backend.party.history.dto;
+
+import java.time.LocalDateTime;
+
+public record PartyHistoryResponse(
+        Long partyId,
+        String displayPartyId,
+        String productId,
+        String productName,
+        String role,
+        String status,
+        LocalDateTime startAt,
+        LocalDateTime endAt
+) {
+}

--- a/src/main/java/pbl2/sub119/backend/party/history/mapper/PartyHistoryQueryMapper.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/mapper/PartyHistoryQueryMapper.java
@@ -1,0 +1,13 @@
+package pbl2.sub119.backend.party.history.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import pbl2.sub119.backend.party.history.dto.PartyHistoryResponse;
+
+@Mapper
+public interface PartyHistoryQueryMapper {
+
+    // 내 파티 히스토리 목록 조회
+    List<PartyHistoryResponse> findMyPartyHistories(@Param("userId") Long userId);
+}

--- a/src/main/java/pbl2/sub119/backend/party/history/service/PartyHistoryQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/service/PartyHistoryQueryService.java
@@ -1,0 +1,27 @@
+package pbl2.sub119.backend.party.history.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pbl2.sub119.backend.common.error.ErrorCode;
+import pbl2.sub119.backend.party.common.exception.PartyException;
+import pbl2.sub119.backend.party.history.dto.PartyHistoryResponse;
+import pbl2.sub119.backend.party.history.mapper.PartyHistoryQueryMapper;
+
+@Service
+@RequiredArgsConstructor
+public class PartyHistoryQueryService {
+
+    private final PartyHistoryQueryMapper partyHistoryQueryMapper;
+
+    // 내 파티 히스토리 조회
+    @Transactional(readOnly = true)
+    public List<PartyHistoryResponse> getMyPartyHistories(final Long userId) {
+        if (userId == null) {
+            throw new PartyException(ErrorCode.PARTY_INVALID_USER_ID);
+        }
+
+        return partyHistoryQueryMapper.findMyPartyHistories(userId);
+    }
+}

--- a/src/main/resources/mapper/admin/AdminUserMapper.xml
+++ b/src/main/resources/mapper/admin/AdminUserMapper.xml
@@ -94,7 +94,6 @@
     </select>
 
     <!-- 파티장으로 이용중인 파티 목록 조회 -->
-    <!-- 파티장으로 이용중인 파티 목록 조회 -->
     <select id="findUsingPartiesByHostUserId" resultMap="adminUserPartyResponseMap">
         SELECT p.id              AS party_id,
                sp.service_name   AS product_name,

--- a/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
+++ b/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="pbl2.sub119.backend.party.history.mapper.PartyHistoryQueryMapper">
+
+    <!-- 내 파티 히스토리 목록 조회 -->
+    <select id="findMyPartyHistories"
+            resultType="pbl2.sub119.backend.party.history.dto.PartyHistoryResponse">
+        SELECT
+            p.id AS partyId,
+            CONCAT('PTY-', LPAD(p.id, 3, '0')) AS displayPartyId,
+            p.product_id AS productId,
+            sp.service_name AS productName,
+            pm.role AS role,
+            CASE
+                WHEN pm.status IN ('LEFT', 'REMOVED') THEN 'ENDED'
+                WHEN p.operation_status = 'TERMINATED' THEN 'ENDED'
+                ELSE 'USING'
+                END AS status,
+            pm.service_start_at AS startAt,
+            pm.service_end_at AS endAt
+        FROM party_member pm
+                 INNER JOIN party p
+                            ON p.id = pm.party_id
+                 INNER JOIN sub_product sp
+                            ON sp.id = p.product_id
+        WHERE pm.user_id = #{userId}
+        ORDER BY
+            CASE
+                WHEN pm.status IN ('LEFT', 'REMOVED') THEN 1
+                WHEN p.operation_status = 'TERMINATED' THEN 1
+                ELSE 0
+                END,
+            pm.service_start_at DESC,
+            pm.id DESC
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
+++ b/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
@@ -27,6 +27,7 @@
                  INNER JOIN sub_product sp
                             ON sp.id = p.product_id
         WHERE pm.user_id = #{userId}
+          AND pm.status IN ('ACTIVE','LEAVE_RESERVED','SWITCH_WAITING','LEFT','REMOVED')
         ORDER BY
             CASE
                 WHEN pm.status IN ('LEFT', 'REMOVED') THEN 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 파티 히스토리 조회 기능이 추가되었습니다. 이용한 파티 목록과 상품명, 역할, 이용 상태(ENDED/USING 등), 이용 기간을 확인할 수 있습니다.

* **문서**
  * 해당 API의 사용 설명과 응답 필드 의미가 공식 문서에 정리되었습니다.

* **잡무(정리)**
  * 불필요한 매퍼 주석이 제거되어 코드 가독성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->