### PR TITLE
[Payment] API 추가

### DIFF
--- a/src/main/java/pbl2/sub119/backend/toss/controller/PaymentController.java
+++ b/src/main/java/pbl2/sub119/backend/toss/controller/PaymentController.java
@@ -8,6 +8,7 @@ import pbl2.sub119.backend.auth.aop.Auth;
 import pbl2.sub119.backend.auth.entity.Accessor;
 import pbl2.sub119.backend.toss.controller.docs.PaymentDocs;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
+import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
 import pbl2.sub119.backend.toss.service.BillingKeyService;
 
 import java.util.Map;
@@ -37,6 +38,20 @@ public class PaymentController implements PaymentDocs {
             @Auth final Accessor accessor) {
         String customerKey = "submate-" + accessor.getUserId();
         return ResponseEntity.ok(Map.of("customerKey", customerKey));
+    }
+
+    @GetMapping("/billing/me")
+    public ResponseEntity<BillingKeyInfoResponse> getBillingInfo(
+            @Auth final Accessor accessor) {
+        return ResponseEntity.ok(billingKeyService.getBillingInfo(accessor));
+    }
+
+    @PostMapping("/billing/change")
+    public ResponseEntity<Void> changeBillingKey(
+            @Auth final Accessor accessor,
+            @Valid @RequestBody BillingKeyIssueRequest request) {
+        billingKeyService.changeBillingKey(accessor, request);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/pbl2/sub119/backend/toss/controller/docs/PaymentDocs.java
+++ b/src/main/java/pbl2/sub119/backend/toss/controller/docs/PaymentDocs.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import pbl2.sub119.backend.auth.aop.Auth;
 import pbl2.sub119.backend.auth.entity.Accessor;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
+import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
 
 import java.util.Map;
 
@@ -81,6 +82,67 @@ public interface PaymentDocs {
     ResponseEntity<Void> issueBillingKey(
             @Parameter(hidden = true) @Auth Accessor accessor,
             @Parameter(description = "빌링키 발급 요청 정보", required = true)
+            @Valid @RequestBody BillingKeyIssueRequest request
+    );
+
+    @Operation(
+            summary = "내 결제수단 조회",
+            description = """
+                    현재 로그인한 사용자의 ACTIVE 결제수단 메타데이터를 조회합니다.
+                    등록된 결제수단이 없으면 hasBillingKey=false로 응답합니다.
+                    billingKey 원문은 반환하지 않습니다.
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "조회 성공 (결제수단 없을 경우 hasBillingKey=false)"
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 필요",
+                            content = @Content
+                    )
+            }
+    )
+    @GetMapping("/billing/me")
+    ResponseEntity<BillingKeyInfoResponse> getBillingInfo(
+            @Parameter(hidden = true) @Auth Accessor accessor
+    );
+
+    @Operation(
+            summary = "결제수단 변경",
+            description = """
+                    기존 등록된 결제수단을 새 카드로 교체합니다.
+                    프론트에서 토스 SDK 카드 등록 후 받은 authKey를 전달하면,
+                    Toss API로 새 빌링키를 발급받아 기존 row를 UPDATE합니다.
+                    Toss 호출 실패 시 DB는 변경되지 않습니다.
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "결제수단 변경 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "잘못된 요청 또는 Toss 빌링키 발급 실패",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 필요",
+                            content = @Content
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "등록된 결제수단 없음",
+                            content = @Content
+                    )
+            }
+    )
+    @PostMapping("/billing/change")
+    ResponseEntity<Void> changeBillingKey(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @Parameter(description = "새 카드 authKey", required = true)
             @Valid @RequestBody BillingKeyIssueRequest request
     );
 }

--- a/src/main/java/pbl2/sub119/backend/toss/dto/response/BillingKeyInfoResponse.java
+++ b/src/main/java/pbl2/sub119/backend/toss/dto/response/BillingKeyInfoResponse.java
@@ -1,0 +1,29 @@
+package pbl2.sub119.backend.toss.dto.response;
+
+import pbl2.sub119.backend.toss.entity.BillingKeyEntity;
+
+import java.time.LocalDateTime;
+
+public record BillingKeyInfoResponse(
+        boolean hasBillingKey,
+        String customerKey,
+        String cardCompany,
+        String maskedCardNumber,
+        String status,
+        LocalDateTime issuedAt
+) {
+    public static BillingKeyInfoResponse empty() {
+        return new BillingKeyInfoResponse(false, null, null, null, null, null);
+    }
+
+    public static BillingKeyInfoResponse of(BillingKeyEntity entity) {
+        return new BillingKeyInfoResponse(
+                true,
+                entity.getCustomerKey(),
+                entity.getCardCompany(),
+                entity.getMaskedCardNumber(),
+                entity.getStatus().name(),
+                entity.getIssuedAt()
+        );
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/toss/mapper/BillingKeyMapper.java
+++ b/src/main/java/pbl2/sub119/backend/toss/mapper/BillingKeyMapper.java
@@ -11,6 +11,14 @@ import java.util.Optional;
 public interface BillingKeyMapper {
     void insert(BillingKeyEntity billingKey);
     Optional<BillingKeyEntity> findByUserId(@Param("userId") Long userId);
+    Optional<BillingKeyEntity> findAnyByUserId(@Param("userId") Long userId);
     List<BillingKeyEntity> findActiveByPartyId(@Param("partyId") Long partyId);
     void updateStatus(@Param("id") Long id, @Param("status") String status);
+
+    void updateBillingKeyInfo(
+            @Param("id") Long id,
+            @Param("billingKey") String billingKey,
+            @Param("cardCompany") String cardCompany,
+            @Param("maskedCardNumber") String maskedCardNumber
+    );
 }

--- a/src/main/java/pbl2/sub119/backend/toss/service/BillingKeyService.java
+++ b/src/main/java/pbl2/sub119/backend/toss/service/BillingKeyService.java
@@ -11,6 +11,7 @@ import pbl2.sub119.backend.common.error.ErrorCode;
 import pbl2.sub119.backend.toss.client.TossPaymentClient;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
 import pbl2.sub119.backend.toss.dto.request.TossBillingAuthRequest;
+import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
 import pbl2.sub119.backend.toss.dto.response.TossBillingAuthResponse;
 import pbl2.sub119.backend.toss.entity.BillingKeyEntity;
 import pbl2.sub119.backend.toss.event.BillingKeyIssuedEvent;
@@ -53,5 +54,37 @@ public class BillingKeyService {
         billingKeyMapper.insert(billingKey);
 
         eventPublisher.publishEvent(new BillingKeyIssuedEvent(userId, response.billingKey()));
+    }
+
+    @Transactional(readOnly = true)
+    public BillingKeyInfoResponse getBillingInfo(Accessor accessor) {
+        return billingKeyMapper.findByUserId(accessor.getUserId())
+                .map(BillingKeyInfoResponse::of)
+                .orElse(BillingKeyInfoResponse.empty());
+    }
+
+    @Transactional
+    public void changeBillingKey(Accessor accessor, BillingKeyIssueRequest request) {
+        Long userId = accessor.getUserId();
+
+        BillingKeyEntity existing = billingKeyMapper.findAnyByUserId(userId)
+                .orElseThrow(() -> new PaymentException(ErrorCode.PAYMENT_BILLING_KEY_NOT_FOUND));
+
+        String customerKey = "submate-" + userId;
+
+        log.info("빌링키 변경 요청. userId={}, customerKey={}", userId, customerKey);
+
+        TossBillingAuthResponse response = tossPaymentClient.issueBillingKey(
+                new TossBillingAuthRequest(request.authKey(), customerKey)
+        );
+
+        billingKeyMapper.updateBillingKeyInfo(
+                existing.getId(),
+                response.billingKey(),
+                response.cardCompany(),
+                response.cardNumber()
+        );
+
+        log.info("빌링키 변경 완료. userId={}", userId);
     }
 }

--- a/src/main/resources/mapper/toss/BillingKeyMapper.xml
+++ b/src/main/resources/mapper/toss/BillingKeyMapper.xml
@@ -30,6 +30,14 @@
                  )
     </insert>
 
+    <select id="findAnyByUserId" resultMap="BillingKeyMap">
+        SELECT id, user_id, billing_key, customer_key, provider,
+               status, card_company, masked_card_number, issued_at, expired_at
+        FROM billing_key
+        WHERE user_id = #{userId}
+        LIMIT 1
+    </select>
+
     <select id="findByUserId" resultMap="BillingKeyMap">
         SELECT id, user_id, billing_key, customer_key, provider,
                status, card_company, masked_card_number, issued_at, expired_at
@@ -54,6 +62,16 @@
     <update id="updateStatus">
         UPDATE billing_key
         SET status = #{status}
+        WHERE id = #{id}
+    </update>
+
+    <update id="updateBillingKeyInfo">
+        UPDATE billing_key
+        SET billing_key        = #{billingKey},
+            card_company       = #{cardCompany},
+            masked_card_number = #{maskedCardNumber},
+            issued_at          = NOW(),
+            status             = 'ACTIVE'
         WHERE id = #{id}
     </update>
 


### PR DESCRIPTION
기능 설명
마이페이지 결제수단 관리 API 2종을 추가했습니다.
-- GET /api/v1/payments/billing/me
-- POST /api/v1/payments/billing/change
현재 스키마(billing_key.user_id 유니크)와 기존 결제 로직 전제를 유지하기 위해, 결제수단 변경은 신규 row insert가 아니라 기존 row update 방식으로 처리했습니다.
세부 작업
-- [x] BillingKeyInfoResponse 추가 (결제수단 메타데이터 응답 DTO)
-- [x] BillingKeyMapper / BillingKeyMapper.xml 확장
-- [x] findAnyByUserId 추가 (상태 무관 조회)
-- [x] updateBillingKeyInfo로 기존 billing_key row 갱신
-- [x] BillingKeyService#getBillingInfo 추가
-- [x] BillingKeyService#changeBillingKey 추가
-- [x] PaymentController에 GET /billing/me, POST /billing/change 추가
-- [x] PaymentDocs Swagger 문서 반영
-- [x] Redis idempotency 관련 변경 롤백(이번 범위 제외)
ETC
동작 요약
-- GET /billing/me: ACTIVE 결제수단 메타데이터 반환, 없으면 hasBillingKey=false
-- POST /billing/change: authKey로 Toss 발급 성공 시 기존 row update, 실패 시 기존 데이터 유지
영향도
-- 자동결제/readiness의 ACTIVE 1건 전제 유지
-- 스키마 변경 없음
-- Redis 의존 변경 없음
확인 결과
-- 두 API 로컬 호출 정상 동작 확인 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 사용자의 현재 청구 정보(카드사, 마스킹된 카드번호 등)를 조회할 수 있는 기능을 추가했습니다.
  * 등록된 카드 정보를 새로운 카드로 변경할 수 있는 기능을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->