### PR TITLE
fix: 즉시 참여 시 매칭 이력 누락 및 상태값 MATCHED로 통일

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/cycle/listener/PartyCyclePaymentEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/party/cycle/listener/PartyCyclePaymentEventListener.java
@@ -1,0 +1,106 @@
+package pbl2.sub119.backend.party.cycle.listener;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import pbl2.sub119.backend.common.enumerated.PartyMemberStatus;
+import pbl2.sub119.backend.party.common.entity.PartyMember;
+import pbl2.sub119.backend.party.common.enumerated.OperationStatus;
+import pbl2.sub119.backend.party.common.enumerated.PartyHistoryEventType;
+import pbl2.sub119.backend.party.common.enumerated.PartyRole;
+import pbl2.sub119.backend.party.common.mapper.PartyMapper;
+import pbl2.sub119.backend.party.common.mapper.PartyMemberMapper;
+import pbl2.sub119.backend.party.common.service.PartyHistoryService;
+import pbl2.sub119.backend.party.cycle.service.PartyCycleService;
+import pbl2.sub119.backend.payment.event.PartyCyclePaymentCompletedEvent;
+import pbl2.sub119.backend.payment.event.PartyCyclePaymentFailedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PartyCyclePaymentEventListener {
+
+    private final PartyCycleService partyCycleService;
+    private final PartyHistoryService partyHistoryService;
+    private final PartyMapper partyMapper;
+    private final PartyMemberMapper partyMemberMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onPaymentCompleted(PartyCyclePaymentCompletedEvent event) {
+        log.info("결제 완료 이벤트 수신. partyId={}, partyCycleId={}, cycleNo={}",
+                event.partyId(), event.partyCycleId(), event.cycleNo());
+
+        if (event.cycleNo() == 1) {
+            handleFirstCycleCompletion(event.partyId());
+        } else {
+            handleRecurringCycleCompletion(event.partyId());
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void onPaymentFailed(PartyCyclePaymentFailedEvent event) {
+        log.info("결제 실패 이벤트 수신. partyId={}, partyCycleId={}, reason={}",
+                event.partyId(), event.partyCycleId(), event.reason());
+
+        // operationStatus 복구 불필요:
+        // AutoPaymentService는 결제 중 operationStatus를 변경하지 않으므로
+        // 첫 회차 실패 시 파티는 이미 WAITING_START 상태 유지.
+        partyHistoryService.saveHistory(
+                event.partyId(),
+                null,
+                PartyHistoryEventType.PAYMENT_EXECUTION_FAILED,
+                "{\"reason\":\"" + event.reason() + "\""
+                        + ",\"failedCount\":" + event.failedMemberCount()
+                        + ",\"pendingCount\":" + event.pendingMemberCount() + "}",
+                null
+        );
+    }
+
+    private void handleFirstCycleCompletion(Long partyId) {
+        // PENDING 멤버 ACTIVE 처리 + 멤버별 성공 히스토리 기록
+        List<PartyMember> pendingMembers = partyMemberMapper.findPendingMembers(partyId);
+        for (PartyMember member : pendingMembers) {
+            partyMemberMapper.updateStatusAndActivatedAt(member.getId(), PartyMemberStatus.ACTIVE);
+            partyHistoryService.saveHistory(
+                    partyId,
+                    member.getId(),
+                    PartyHistoryEventType.PAYMENT_EXECUTION_SUCCEEDED,
+                    "{\"userId\":" + member.getUserId() + "}",
+                    member.getUserId()
+            );
+        }
+
+        // operationStatus ACTIVE 반영
+        partyMapper.updateOperationStatus(partyId, OperationStatus.ACTIVE);
+
+        // provision 시작 + current_member_count / recruit_status / vacancy_type 갱신
+        partyCycleService.handleCycleStart(partyId);
+    }
+
+    private void handleRecurringCycleCompletion(Long partyId) {
+        // 상태 전환 전 결제 대상(ACTIVE + LEAVE_RESERVED MEMBER)에 대해 먼저 히스토리 기록
+        partyMemberMapper.findMembersByPartyId(partyId).stream()
+                .filter(m -> m.getRole() == PartyRole.MEMBER)
+                .filter(m -> m.getStatus() == PartyMemberStatus.ACTIVE
+                        || m.getStatus() == PartyMemberStatus.LEAVE_RESERVED)
+                .forEach(member -> partyHistoryService.saveHistory(
+                        partyId,
+                        member.getId(),
+                        PartyHistoryEventType.PAYMENT_EXECUTION_SUCCEEDED,
+                        "{\"userId\":" + member.getUserId() + "}",
+                        member.getUserId()
+                ));
+
+        // LEAVE_RESERVED → LEFT, SWITCH_WAITING → ACTIVE
+        // + current_member_count / recruit_status / vacancy_type 갱신
+        // + provision 멤버 구성 변경 반영
+        partyCycleService.confirmRecurringCycleStart(partyId);
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/party/cycle/listener/PartyCyclePaymentEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/party/cycle/listener/PartyCyclePaymentEventListener.java
@@ -1,6 +1,9 @@
 package pbl2.sub119.backend.party.cycle.listener;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -29,6 +32,7 @@ public class PartyCyclePaymentEventListener {
     private final PartyHistoryService partyHistoryService;
     private final PartyMapper partyMapper;
     private final PartyMemberMapper partyMemberMapper;
+    private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -52,15 +56,22 @@ public class PartyCyclePaymentEventListener {
         // operationStatus 복구 불필요:
         // AutoPaymentService는 결제 중 operationStatus를 변경하지 않으므로
         // 첫 회차 실패 시 파티는 이미 WAITING_START 상태 유지.
-        partyHistoryService.saveHistory(
-                event.partyId(),
-                null,
-                PartyHistoryEventType.PAYMENT_EXECUTION_FAILED,
-                "{\"reason\":\"" + event.reason() + "\""
-                        + ",\"failedCount\":" + event.failedMemberCount()
-                        + ",\"pendingCount\":" + event.pendingMemberCount() + "}",
-                null
-        );
+        try {
+            final String detail = objectMapper.writeValueAsString(Map.of(
+                    "reason", event.reason(),
+                    "failedCount", event.failedMemberCount(),
+                    "pendingCount", event.pendingMemberCount()
+            ));
+            partyHistoryService.saveHistory(
+                    event.partyId(),
+                    null,
+                    PartyHistoryEventType.PAYMENT_EXECUTION_FAILED,
+                    detail,
+                    null
+            );
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("결제 실패 이력 직렬화 오류. partyId=" + event.partyId(), e);
+        }
     }
 
     private void handleFirstCycleCompletion(Long partyId) {

--- a/src/main/java/pbl2/sub119/backend/party/join/controller/docs/PartyJoinDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/join/controller/docs/PartyJoinDocs.java
@@ -59,7 +59,7 @@ public interface PartyJoinDocs {
                     - 바로 참여 가능한 파티가 없으면 자동 매칭 대기 상태로 등록합니다.
 
                     상태값 안내
-                    - ACTIVE : 즉시 참여가 완료된 상태
+                    - MATCHED : 즉시 참여가 완료된 상태
                     - WAITING : 자동 매칭 대기열에 등록된 상태
                     - CANCELED : 사용자가 자동 매칭 신청을 취소한 상태
                     """,

--- a/src/main/java/pbl2/sub119/backend/party/join/service/PartyJoinCommandService.java
+++ b/src/main/java/pbl2/sub119/backend/party/join/service/PartyJoinCommandService.java
@@ -34,11 +34,25 @@ public class PartyJoinCommandService {
             try {
                 partyJoinService.joinParty(targetParty.getId(), userId);
 
+                final LocalDateTime now = LocalDateTime.now();
+                final MatchWaitingQueue immediateQueue = MatchWaitingQueue.builder()
+                        .productId(productId)
+                        .userId(userId)
+                        .status(MatchWaitingStatus.MATCHED)
+                        .requestedAt(now)
+                        .matchedAt(now)
+                        .canceledAt(null)
+                        .targetPartyId(targetParty.getId())
+                        .createdAt(now)
+                        .updatedAt(now)
+                        .build();
+                matchWaitingQueueMapper.insertMatchWaitingQueue(immediateQueue);
+
                 return new PartyJoinApplyResponse(
                         true,
                         false,
                         targetParty.getId(),
-                        null,
+                        immediateQueue.getId(),
                         "즉시 참여가 완료되었습니다."
                 );
             } catch (PartyException e) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 그룹 결제 이벤트 처리 기능이 추가되었습니다. 초기 사이클에서 결제 성공 시 대기 중인 멤버를 활성화 상태로 전환하고 결제 기록을 저장합니다. 반복 사이클에서는 활성 멤버의 결제 상태를 기록하며, 결제 실패 시 실패 정보와 상세 내역을 기록합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->