### PR TITLE
fix: 파티 이용 멤버 목록 응답에 파티원 이메일 누락 수정

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/provision/dto/response/PartyProvisionMemberResponse.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/dto/response/PartyProvisionMemberResponse.java
@@ -9,6 +9,7 @@ public record PartyProvisionMemberResponse(
         Long partyMemberId,
         Long userId,
         String nickname,
+        String submateEmail,
         ProvisionMemberStatus memberStatus,
         LocalDateTime inviteSentAt,
         LocalDateTime mustCompleteBy,

--- a/src/main/resources/mapper/partyprovision/PartyProvisionMemberMapper.xml
+++ b/src/main/resources/mapper/partyprovision/PartyProvisionMemberMapper.xml
@@ -33,6 +33,7 @@
             <arg column="party_member_id" javaType="java.lang.Long"/>
             <arg column="user_id" javaType="java.lang.Long"/>
             <arg column="nickname" javaType="java.lang.String"/>
+            <arg column="submate_email" javaType="java.lang.String"/>
             <arg column="member_status"
                  javaType="pbl2.sub119.backend.party.provision.enumerated.ProvisionMemberStatus"/>
             <arg column="invite_sent_at" javaType="java.time.LocalDateTime"/>
@@ -149,6 +150,7 @@
             pom.party_member_id,
             pom.user_id,
             u.nickname,
+            u.submate_email,
             pom.member_status,
             pom.invite_sent_at,
             pom.must_complete_by,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 파티 멤버 조회 시 응답에 서브메이트 이메일 주소 정보가 포함되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->