### PR TITLE
feat: 파티 설정 정보 및 수수료 상세 안내 조회 API 구현

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/settings/controller/PartySettingsController.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/controller/PartySettingsController.java
@@ -1,0 +1,41 @@
+package pbl2.sub119.backend.party.settings.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.party.settings.controller.docs.PartySettingsDocs;
+import pbl2.sub119.backend.party.settings.dto.response.PartyFeeDetailResponse;
+import pbl2.sub119.backend.party.settings.dto.response.PartySettingsResponse;
+import pbl2.sub119.backend.party.settings.service.PartySettingsQueryService;
+
+@RestController
+@RequestMapping("/api/v1/parties")
+@RequiredArgsConstructor
+public class PartySettingsController implements PartySettingsDocs {
+
+    private final PartySettingsQueryService partySettingsQueryService;
+
+    @Override
+    public ResponseEntity<PartySettingsResponse> getPartySettings(
+            @Auth final Accessor accessor,
+            @PathVariable final Long partyId
+    ) {
+        return ResponseEntity.ok(
+                partySettingsQueryService.getSettings(accessor.getUserId(), partyId)
+        );
+    }
+
+    @Override
+    public ResponseEntity<PartyFeeDetailResponse> getPartyFeeDetail(
+            @Auth final Accessor accessor,
+            @PathVariable final Long partyId
+    ) {
+        return ResponseEntity.ok(
+                partySettingsQueryService.getFeeDetail(accessor.getUserId(), partyId)
+        );
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/party/settings/controller/docs/PartySettingsDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/controller/docs/PartySettingsDocs.java
@@ -1,0 +1,97 @@
+package pbl2.sub119.backend.party.settings.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import pbl2.sub119.backend.auth.aop.Auth;
+import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.party.settings.dto.response.PartyFeeDetailResponse;
+import pbl2.sub119.backend.party.settings.dto.response.PartySettingsResponse;
+
+@Tag(name = "Party Settings API", description = "파티 설정 및 정산/결제 정보 조회 API")
+public interface PartySettingsDocs {
+
+    @Operation(
+            summary = "파티 설정 정보 조회",
+            description = """
+                    파티 상세 화면의 설정 버튼 클릭 시 호출합니다.
+                    로그인한 사용자의 역할(파티장/파티원)에 따라 다른 필드를 반환합니다.
+
+                    파티장(HOST) 반환 필드
+                    - ottServiceName : OTT 서비스명
+                    - partyCreatedAt : 파티 생성일
+                    - settlementDayOfMonth : 정산일 (매달 n일)
+                    - monthlySettlementAmount : 매달 정산받는 금액 (원)
+                    - settlementBankName : 정산 계좌 은행명 (미등록 시 null)
+                    - settlementAccountMasked : 마스킹된 계좌번호 (미등록 시 null)
+
+                    파티원(MEMBER) 반환 필드
+                    - ottServiceName : OTT 서비스명
+                    - partyCreatedAt : 파티 생성일
+                    - monthlyPaymentAmount : 매달 결제 금액 (수수료 포함, 원)
+                    - billingDayOfMonth : 결제일 (매달 n일)
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "설정 정보 조회 성공",
+                            content = @Content(schema = @Schema(implementation = PartySettingsResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "403", description = "해당 파티의 멤버가 아님"),
+                    @ApiResponse(responseCode = "404", description = "파티 또는 결제 사이클 없음")
+            }
+    )
+    @GetMapping("/{partyId}/settings")
+    ResponseEntity<PartySettingsResponse> getPartySettings(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @PathVariable Long partyId
+    );
+
+    @Operation(
+            summary = "수수료 및 정산/결제 상세 안내 조회",
+            description = """
+                    설정 페이지의 '정산 내역 자세히 보기' 버튼 클릭 시 호출합니다.
+                    파티장과 파티원 각각 다른 정보를 반환합니다.
+
+                    파티장(HOST) — 수수료 및 정산일 안내
+                    - memberCount : 파티원 수
+                    - membersShareAmount : 파티원 n명의 OTT 분담금 합계 (원)
+                    - platformFee : 픽플러스 수수료 490원 (파티원 할인 적용 고정값)
+                    - monthlySettlementAmount : 매달 정산받는 금액 (원)
+                    - nextSettlementDate : 다음 정산일
+                    - isSettlementGuaranteeApplied : 정산 보장제 적용 여부
+
+                    파티원(MEMBER) — 수수료 및 결제일 안내
+                    - monthlyPaymentAmount : 매달 결제 금액 (수수료 포함, 원)
+                    - platformFee : 픽플러스 수수료 990원 (고정값)
+                    - ottUsageFee : OTT 순수 분담금 (결제금액 - 수수료, 원)
+                    - nextBillingDate : 다음 결제일
+
+                    계산 공식
+                    - membersShareAmount = 파티원 수 × (결제금액 - 990)
+                    - monthlySettlementAmount = membersShareAmount - 490
+                    - ottUsageFee = monthlyPaymentAmount - 990
+                    - 다음 정산/결제일 = 현재 billingDueAt + 1개월
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "수수료 상세 조회 성공",
+                            content = @Content(schema = @Schema(implementation = PartyFeeDetailResponse.class))
+                    ),
+                    @ApiResponse(responseCode = "403", description = "해당 파티의 멤버가 아님"),
+                    @ApiResponse(responseCode = "404", description = "파티 또는 결제 사이클 없음")
+            }
+    )
+    @GetMapping("/{partyId}/settings/fee-detail")
+    ResponseEntity<PartyFeeDetailResponse> getPartyFeeDetail(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @PathVariable Long partyId
+    );
+}

--- a/src/main/java/pbl2/sub119/backend/party/settings/controller/docs/PartySettingsDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/controller/docs/PartySettingsDocs.java
@@ -44,7 +44,7 @@ public interface PartySettingsDocs {
                             content = @Content(schema = @Schema(implementation = PartySettingsResponse.class))
                     ),
                     @ApiResponse(responseCode = "403", description = "해당 파티의 멤버가 아님"),
-                    @ApiResponse(responseCode = "404", description = "파티 또는 결제 사이클 없음")
+                    @ApiResponse(responseCode = "404", description = "파티, 서브상품 또는 결제 사이클 없음")
             }
     )
     @GetMapping("/{partyId}/settings")

--- a/src/main/java/pbl2/sub119/backend/party/settings/dto/response/PartyFeeDetailResponse.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/dto/response/PartyFeeDetailResponse.java
@@ -1,0 +1,19 @@
+package pbl2.sub119.backend.party.settings.dto.response;
+
+import java.time.LocalDate;
+
+public record PartyFeeDetailResponse(
+        String role,
+        // HOST
+        Integer memberCount,
+        Long membersShareAmount,
+        Long platformFee,
+        Long monthlySettlementAmount,
+        LocalDate nextSettlementDate,
+        Boolean isSettlementGuaranteeApplied,
+        // MEMBER
+        Long monthlyPaymentAmount,
+        Long ottUsageFee,
+        LocalDate nextBillingDate
+) {
+}

--- a/src/main/java/pbl2/sub119/backend/party/settings/dto/response/PartySettingsResponse.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/dto/response/PartySettingsResponse.java
@@ -1,0 +1,18 @@
+package pbl2.sub119.backend.party.settings.dto.response;
+
+import java.time.LocalDate;
+
+public record PartySettingsResponse(
+        String role,
+        String ottServiceName,
+        LocalDate partyCreatedAt,
+        // HOST
+        Integer settlementDayOfMonth,
+        Long monthlySettlementAmount,
+        String settlementBankName,
+        String settlementAccountMasked,
+        // MEMBER
+        Long monthlyPaymentAmount,
+        Integer billingDayOfMonth
+) {
+}

--- a/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
@@ -161,7 +161,7 @@ public class PartySettingsQueryService {
 
     private PartyCycle getRunningCycle(final Long partyId) {
         final PartyCycle cycle = partyCycleMapper.findLatestPendingOrRunningCycle(
-                partyId, PartyCycleStatus.RUNNING, PartyCycleStatus.RUNNING
+                partyId, PartyCycleStatus.PAYMENT_PENDING, PartyCycleStatus.RUNNING
         );
         if (cycle == null) {
             throw new PartyException(ErrorCode.PAYMENT_CYCLE_NOT_FOUND);

--- a/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
@@ -1,0 +1,179 @@
+package pbl2.sub119.backend.party.settings.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
+import pbl2.sub119.backend.bankaccounts.mapper.BankMapper;
+import pbl2.sub119.backend.common.enumerated.PartyMemberStatus;
+import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
+import pbl2.sub119.backend.common.error.ErrorCode;
+import pbl2.sub119.backend.party.common.entity.Party;
+import pbl2.sub119.backend.party.common.entity.PartyMember;
+import pbl2.sub119.backend.party.common.enumerated.PartyRole;
+import pbl2.sub119.backend.party.common.exception.PartyException;
+import pbl2.sub119.backend.party.common.mapper.PartyMapper;
+import pbl2.sub119.backend.party.common.mapper.PartyMemberMapper;
+import pbl2.sub119.backend.party.settings.dto.response.PartyFeeDetailResponse;
+import pbl2.sub119.backend.party.settings.dto.response.PartySettingsResponse;
+import pbl2.sub119.backend.payment.entity.PartyCycle;
+import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
+import pbl2.sub119.backend.payment.policy.FeePolicy;
+import pbl2.sub119.backend.subproduct.entity.SubProduct;
+import pbl2.sub119.backend.subproduct.mapper.SubProductMapper;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PartySettingsQueryService {
+
+    private final PartyMapper partyMapper;
+    private final PartyMemberMapper partyMemberMapper;
+    private final SubProductMapper subProductMapper;
+    private final PartyCycleMapper partyCycleMapper;
+    private final BankMapper bankMapper;
+
+    public PartySettingsResponse getSettings(final Long userId, final Long partyId) {
+        final Party party = getParty(partyId);
+        final PartyMember member = getActiveMember(userId, partyId);
+        final SubProduct subProduct = getSubProduct(party.getProductId());
+        final PartyCycle cycle = getRunningCycle(partyId);
+
+        if (member.getRole() == PartyRole.HOST) {
+            return buildHostSettings(party, subProduct, cycle);
+        }
+        return buildMemberSettings(party, subProduct, cycle);
+    }
+
+    public PartyFeeDetailResponse getFeeDetail(final Long userId, final Long partyId) {
+        getParty(partyId);
+        final PartyMember member = getActiveMember(userId, partyId);
+        final PartyCycle cycle = getRunningCycle(partyId);
+
+        if (member.getRole() == PartyRole.HOST) {
+            return buildHostFeeDetail(cycle);
+        }
+        return buildMemberFeeDetail(cycle);
+    }
+
+    private PartySettingsResponse buildHostSettings(
+            final Party party,
+            final SubProduct subProduct,
+            final PartyCycle cycle
+    ) {
+        final BankAccount settlementAccount = findSettlementAccount(party.getHostUserId());
+        final long membersShareAmount =
+                (long) cycle.getMemberCountSnapshot() * (cycle.getPricePerMemberSnapshot() - FeePolicy.MEMBER_FEE);
+        final long monthlySettlementAmount = membersShareAmount - FeePolicy.HOST_FEE;
+
+        return new PartySettingsResponse(
+                "HOST",
+                subProduct.getServiceName(),
+                party.getCreatedAt().toLocalDate(),
+                cycle.getBillingDueAt().getDayOfMonth(),
+                monthlySettlementAmount,
+                settlementAccount != null ? settlementAccount.getBankName() : null,
+                settlementAccount != null ? settlementAccount.getAccountNumMasked() : null,
+                null,
+                null
+        );
+    }
+
+    private PartySettingsResponse buildMemberSettings(
+            final Party party,
+            final SubProduct subProduct,
+            final PartyCycle cycle
+    ) {
+        return new PartySettingsResponse(
+                "MEMBER",
+                subProduct.getServiceName(),
+                party.getCreatedAt().toLocalDate(),
+                null,
+                null,
+                null,
+                null,
+                (long) cycle.getPricePerMemberSnapshot(),
+                cycle.getBillingDueAt().getDayOfMonth()
+        );
+    }
+
+    private PartyFeeDetailResponse buildHostFeeDetail(final PartyCycle cycle) {
+        final long membersShareAmount =
+                (long) cycle.getMemberCountSnapshot() * (cycle.getPricePerMemberSnapshot() - FeePolicy.MEMBER_FEE);
+        final long monthlySettlementAmount = membersShareAmount - FeePolicy.HOST_FEE;
+
+        return new PartyFeeDetailResponse(
+                "HOST",
+                cycle.getMemberCountSnapshot(),
+                membersShareAmount,
+                FeePolicy.HOST_FEE,
+                monthlySettlementAmount,
+                cycle.getBillingDueAt().plusMonths(1).toLocalDate(),
+                true,
+                null,
+                null,
+                null
+        );
+    }
+
+    private PartyFeeDetailResponse buildMemberFeeDetail(final PartyCycle cycle) {
+        final long monthlyPaymentAmount = cycle.getPricePerMemberSnapshot();
+        final long ottUsageFee = monthlyPaymentAmount - FeePolicy.MEMBER_FEE;
+
+        return new PartyFeeDetailResponse(
+                "MEMBER",
+                null,
+                null,
+                FeePolicy.MEMBER_FEE,
+                null,
+                null,
+                null,
+                monthlyPaymentAmount,
+                ottUsageFee,
+                cycle.getBillingDueAt().plusMonths(1).toLocalDate()
+        );
+    }
+
+    private Party getParty(final Long partyId) {
+        final Party party = partyMapper.findById(partyId);
+        if (party == null) {
+            throw new PartyException(ErrorCode.PARTY_NOT_FOUND);
+        }
+        return party;
+    }
+
+    private PartyMember getActiveMember(final Long userId, final Long partyId) {
+        final PartyMember member = partyMemberMapper.findByPartyIdAndUserId(partyId, userId);
+        if (member == null
+                || member.getStatus() == PartyMemberStatus.LEFT
+                || member.getStatus() == PartyMemberStatus.REMOVED) {
+            throw new PartyException(ErrorCode.PARTY_LEAVE_FORBIDDEN);
+        }
+        return member;
+    }
+
+    private SubProduct getSubProduct(final String productId) {
+        return subProductMapper.findById(productId)
+                .orElseThrow(() -> new PartyException(ErrorCode.SUB_PRODUCT_NOT_FOUND));
+    }
+
+    private PartyCycle getRunningCycle(final Long partyId) {
+        final PartyCycle cycle = partyCycleMapper.findLatestPendingOrRunningCycle(
+                partyId, PartyCycleStatus.RUNNING, PartyCycleStatus.RUNNING
+        );
+        if (cycle == null) {
+            throw new PartyException(ErrorCode.PAYMENT_CYCLE_NOT_FOUND);
+        }
+        return cycle;
+    }
+
+    private BankAccount findSettlementAccount(final Long hostUserId) {
+        final List<BankAccount> accounts = bankMapper.findAllByUserId(hostUserId);
+        return accounts.stream()
+                .filter(a -> a.getAccountType() == AccountType.SETTLEMENT)
+                .findFirst()
+                .orElse(null);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 인증된 사용자가 자신의 파티 설정 정보(역할, OTT 서비스, 정산 정보 등)를 조회할 수 있는 API 엔드포인트 추가
  * 파티별 요금 상세정보(멤버 공유금, 플랫폼 수수료, 정산금, 결제금 등)를 확인할 수 있는 API 엔드포인트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->