### PR TITLE
[Payment] 초기 결제 트리거 변경 및 결제 내역 조회 

### DIFF
--- a/src/main/java/pbl2/sub119/backend/admin/controller/docs/AdminDocs.java
+++ b/src/main/java/pbl2/sub119/backend/admin/controller/docs/AdminDocs.java
@@ -344,16 +344,21 @@ public interface AdminDocs {
                 summary = "결제 사이클 수동 재시도",
                 description = """
                         FAILED 상태인 결제 사이클을 관리자가 수동으로 재시도합니다.
+                        결제 실패 복구는 이 API를 통한 어드민 명시적 액션만 허용됩니다.
 
                         이 API는 아래 화면에서 사용합니다.
                         - 관리자 결제 실패 관리 페이지
+
+                        결제 재시도 정책:
+                        - 자동 재트리거는 허용되지 않습니다. provision 수정(setupProvision) 또는 빌링키 재등록만으로는 실패한 결제가 재시도되지 않습니다.
+                        - 결제 실패 복구는 반드시 이 API를 통해 어드민이 명시적으로 요청해야 합니다.
+                        - 재시도 요청은 감사 로그(party_history: PAYMENT_RETRY_REQUESTED)에 partyId, partyCycleId, adminId, requestedAt 과 함께 기록됩니다.
 
                         처리 기준:
                         - 대상 사이클의 status 가 FAILED 이어야 합니다.
                         - billing_due_at 기준 7일 이내에만 재시도할 수 있습니다.
                         - FAILED 상태인 멤버 결제 레코드만 PAYMENT_PENDING 으로 초기화합니다.
                           (PAID / CANCELLED 레코드는 유지됩니다.)
-                        - 재시도 요청은 party_history 에 PAYMENT_RETRY_REQUESTED 로 기록됩니다.
                         - 실제 결제 실행은 PaymentExecutionRequestedEvent 를 통해 비동기로 처리됩니다.
 
                         에러 안내:

--- a/src/main/java/pbl2/sub119/backend/party/provision/controller/docs/PartyProvisionDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/controller/docs/PartyProvisionDocs.java
@@ -27,7 +27,7 @@ public interface PartyProvisionDocs {
     @Operation(
             summary = "파티 이용 정보 등록",
             description = """
-                    파티장이 결제 완료 후 파티 이용에 필요한 정보를 등록합니다.
+                    파티장이 결제 전 또는 결제 준비 단계에서 파티 이용에 필요한 정보를 등록합니다.
 
                     이용 정보 제공 방식
                     - ACCOUNT_SHARE : 파티장이 공유 계정 이메일과 비밀번호를 등록하는 방식입니다.
@@ -43,6 +43,12 @@ public interface PartyProvisionDocs {
                     - REQUIRED : 파티원이 아직 이용 확인을 하지 않아 확인이 필요한 상태입니다.
                     - ACTIVE : 파티원이 이용 확인까지 완료하여 현재 정상 이용 중인 상태입니다.
                     - RESET_REQUIRED : 파티장이 이용 정보를 다시 변경하여 파티원이 다시 확인해야 하는 상태입니다.
+
+                    결제 트리거 정책 안내
+                    - 이 API는 운영 정보 등록/수정 전용입니다. 결제 재시도 수단이 아닙니다.
+                    - 최초 provision 등록 시, 모집 완료 + 전원 빌링키 보유 조건을 충족하면 초기 결제가 자동 트리거됩니다.
+                    - 단, 이미 결제 실패(FAILED) 이력이 있는 경우 이 API로 결제가 재시도되지 않습니다.
+                    - 결제 실패 복구는 관리자 명시적 retry API(POST /api/v1/admin/payments/cycles/{id}/retry)를 통해서만 가능합니다.
                     """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     required = true,

--- a/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionCommandService.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionCommandService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import pbl2.sub119.backend.notification.event.event.AccountSharedCredentialRequiredEvent;
 import pbl2.sub119.backend.notification.event.event.InviteLinkRequiredEvent;
 import pbl2.sub119.backend.common.error.ErrorCode;
+import pbl2.sub119.backend.party.event.PartyProvisionSetupCompletedEvent;
 import pbl2.sub119.backend.common.util.CryptoUtil;
 import pbl2.sub119.backend.party.common.entity.Party;
 import pbl2.sub119.backend.party.common.entity.PartyMember;
@@ -91,6 +92,7 @@ public class PartyProvisionCommandService {
             initializeMembers(provision.getId(), partyId, party.getHostUserId(), now);
 
             publishProvisionRequiredEvent(partyId, provision.getId(), party.getHostUserId(), request.provisionType());
+            publishProvisionSetupCompletedEvent(partyId);
 
             return new PartyProvisionSetupResponse(
                     provision.getId(),
@@ -115,6 +117,7 @@ public class PartyProvisionCommandService {
 
         // 다시 저장하면 기존 멤버는 처음부터 다시 확인
         resetMemberRows(existingProvision.getId(), partyId, party.getHostUserId(), now);
+        publishProvisionSetupCompletedEvent(partyId);
 
         return new PartyProvisionSetupResponse(
                 existingProvision.getId(),
@@ -454,6 +457,11 @@ public class PartyProvisionCommandService {
         }
 
         return cryptoUtil.encrypt(request.sharedAccountPassword());
+    }
+
+    // provision 설정 완료 이벤트 발행 - 리스너가 @TransactionalEventListener(AFTER_COMMIT)이므로 트랜잭션 커밋 후 실행 보장
+    private void publishProvisionSetupCompletedEvent(final Long partyId) {
+        eventPublisher.publishEvent(new PartyProvisionSetupCompletedEvent(partyId));
     }
 
     // provision 최초 등록 후 파티원에게 알림 이벤트 발행

--- a/src/main/java/pbl2/sub119/backend/payment/dto/response/PaymentHistoryItem.java
+++ b/src/main/java/pbl2/sub119/backend/payment/dto/response/PaymentHistoryItem.java
@@ -1,0 +1,24 @@
+package pbl2.sub119.backend.payment.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.payment.enumerated.MemberPaymentStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentHistoryItem {
+    private Long partyId;
+    private Long partyCycleId;
+    private String serviceName;
+    private Integer amount;
+    private MemberPaymentStatus status;
+    private LocalDateTime paidAt;
+    private LocalDateTime failedAt;
+    private String failureReason;
+    private String failureCode;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/pbl2/sub119/backend/payment/listener/BillingKeyIssuedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/BillingKeyIssuedEventListener.java
@@ -1,60 +1,17 @@
 package pbl2.sub119.backend.payment.listener;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import pbl2.sub119.backend.payment.entity.PartyCycle;
-import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
-import pbl2.sub119.backend.payment.mapper.PaymentExecutionQueryMapper;
-import pbl2.sub119.backend.payment.service.InitialPaymentCycleService;
-import pbl2.sub119.backend.payment.service.PartyPaymentReadinessService;
 import pbl2.sub119.backend.toss.event.BillingKeyIssuedEvent;
-
-import java.util.List;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class BillingKeyIssuedEventListener {
-
-    private final PartyPaymentReadinessService partyPaymentReadinessService;
-    private final InitialPaymentCycleService initialPaymentCycleService;
-    private final PaymentExecutionQueryMapper paymentExecutionQueryMapper;
-    private final ApplicationEventPublisher eventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(BillingKeyIssuedEvent event) {
-        Long userId = event.userId();
-
-        List<Long> candidatePartyIds =
-                paymentExecutionQueryMapper.findPendingPartyIdsByUserId(userId);
-
-        for (Long partyId : candidatePartyIds) {
-            try {
-                tryTriggerInitialPayment(partyId);
-            } catch (Exception e) {
-                log.error("초기 결제 트리거 실패. partyId={}", partyId, e);
-            }
-        }
-    }
-
-    private void tryTriggerInitialPayment(Long partyId) {
-        // isReady: capacity 충족 + 전원 빌링키 보유 + PAYMENT_PENDING/RUNNING cycle 없음 확인 포함
-        if (!partyPaymentReadinessService.isReady(partyId)) {
-            log.info("파티 결제 준비 미완료. partyId={}", partyId);
-            return;
-        }
-
-        // DuplicateKeyException 시 기존 cycle 반환 (내부 멱등 처리)
-        PartyCycle partyCycle = initialPaymentCycleService.createInitialCycle(partyId);
-
-        log.info("파티 결제일 확정 완료. partyId={}, partyCycleId={}", partyId, partyCycle.getId());
-
-        eventPublisher.publishEvent(
-                new PaymentExecutionRequestedEvent(partyId, partyCycle.getId())
-        );
+        log.info("빌링키 발급 완료. userId={}", event.userId());
     }
 }

--- a/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import pbl2.sub119.backend.party.event.PartyProvisionSetupCompletedEvent;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
+import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
 import pbl2.sub119.backend.payment.service.InitialPaymentCycleService;
 import pbl2.sub119.backend.payment.service.PartyPaymentReadinessService;
 
@@ -21,6 +22,7 @@ public class PartyProvisionSetupCompletedEventListener {
 
     private final PartyPaymentReadinessService partyPaymentReadinessService;
     private final InitialPaymentCycleService initialPaymentCycleService;
+    private final PartyCycleMapper partyCycleMapper;
     private final ApplicationEventPublisher eventPublisher;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -30,6 +32,12 @@ public class PartyProvisionSetupCompletedEventListener {
 
         if (!partyPaymentReadinessService.isReady(partyId)) {
             log.info("파티 결제 준비 미완료. partyId={}", partyId);
+            return;
+        }
+
+        // 초기 결제(cycle_no=1)가 이미 FAILED인 경우 자동 재트리거 차단 — 어드민 명시적 retry만 허용
+        if (partyCycleMapper.existsFailedInitialCycle(partyId)) {
+            log.warn("초기 결제 자동 재트리거 차단. partyId={}, reason=FAILED_INITIAL_CYCLE_EXISTS", partyId);
             return;
         }
 

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMapper.java
@@ -52,4 +52,7 @@ public interface PartyCycleMapper {
 
     // deadline 전용: PAYMENT_PENDING / PROCESSING 상태 cycle을 FAILED로 전이
     int failIfPendingOrProcessing(@Param("partyCycleId") Long partyCycleId);
+
+    // 초기 결제(cycle_no=1) FAILED 여부만 확인 — 반복회차 실패와 구분
+    boolean existsFailedInitialCycle(@Param("partyId") Long partyId);
 }

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/UserPaymentHistoryQueryMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/UserPaymentHistoryQueryMapper.java
@@ -1,0 +1,17 @@
+package pbl2.sub119.backend.payment.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import pbl2.sub119.backend.payment.dto.response.PaymentHistoryItem;
+
+import java.util.List;
+
+@Mapper
+public interface UserPaymentHistoryQueryMapper {
+
+    List<PaymentHistoryItem> findByUserId(
+            @Param("userId") Long userId,
+            @Param("size") int size,
+            @Param("offset") int offset
+    );
+}

--- a/src/main/java/pbl2/sub119/backend/payment/service/PaymentHistoryQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/PaymentHistoryQueryService.java
@@ -18,8 +18,15 @@ public class PaymentHistoryQueryService {
 
     @Transactional(readOnly = true)
     public List<PaymentHistoryItem> getMyPaymentHistory(Long userId, int page, int size) {
+        int normalizedPage = Math.max(page, 0);
         int normalizedSize = Math.min(Math.max(size, 1), MAX_SIZE);
-        int offset = Math.max(page, 0) * normalizedSize;
+
+        long offsetLong = (long) normalizedPage * normalizedSize;
+        if (offsetLong > Integer.MAX_VALUE) {
+            offsetLong = Integer.MAX_VALUE; // 또는 예외 처리
+        }
+
+        int offset = (int) offsetLong;
         return userPaymentHistoryQueryMapper.findByUserId(userId, normalizedSize, offset);
     }
 }

--- a/src/main/java/pbl2/sub119/backend/payment/service/PaymentHistoryQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/PaymentHistoryQueryService.java
@@ -1,0 +1,25 @@
+package pbl2.sub119.backend.payment.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pbl2.sub119.backend.payment.dto.response.PaymentHistoryItem;
+import pbl2.sub119.backend.payment.mapper.UserPaymentHistoryQueryMapper;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentHistoryQueryService {
+
+    private static final int MAX_SIZE = 100;
+
+    private final UserPaymentHistoryQueryMapper userPaymentHistoryQueryMapper;
+
+    @Transactional(readOnly = true)
+    public List<PaymentHistoryItem> getMyPaymentHistory(Long userId, int page, int size) {
+        int normalizedSize = Math.min(Math.max(size, 1), MAX_SIZE);
+        int offset = Math.max(page, 0) * normalizedSize;
+        return userPaymentHistoryQueryMapper.findByUserId(userId, normalizedSize, offset);
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/payment/service/PaymentRetryService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/PaymentRetryService.java
@@ -33,6 +33,8 @@ public class PaymentRetryService {
 
     @Transactional
     public void retry(Long partyCycleId, Long adminId) {
+        final LocalDateTime requestedAt = LocalDateTime.now();
+
         PartyCycle cycle = partyCycleMapper.findById(partyCycleId);
         if (cycle == null) {
             throw new BusinessException(ErrorCode.PAYMENT_CYCLE_NOT_FOUND);
@@ -42,7 +44,7 @@ public class PaymentRetryService {
             throw new BusinessException(ErrorCode.PAYMENT_CYCLE_RETRY_NOT_ALLOWED);
         }
 
-        if (cycle.getBillingDueAt().plusDays(RETRY_DEADLINE_DAYS).isBefore(LocalDateTime.now())) {
+        if (cycle.getBillingDueAt().plusDays(RETRY_DEADLINE_DAYS).isBefore(requestedAt)) {
             throw new BusinessException(ErrorCode.PAYMENT_CYCLE_RETRY_DEADLINE_EXCEEDED);
         }
 
@@ -56,14 +58,15 @@ public class PaymentRetryService {
         // FAILED 멤버만 PAYMENT_PENDING으로 초기화 (PAID/CANCELLED 유지)
         memberPaymentMapper.resetFailedForRetry(partyCycleId);
 
+        final Long partyId = cycle.getPartyId();
+
         partyHistoryService.saveHistory(
-                cycle.getPartyId(), null,
+                partyId, null,
                 PartyHistoryEventType.PAYMENT_RETRY_REQUESTED,
-                buildPayload(partyCycleId, cycle.getCycleNo()),
+                buildPayload(partyCycleId, cycle.getCycleNo(), partyId, adminId, requestedAt),
                 adminId
         );
 
-        Long partyId = cycle.getPartyId();
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -71,10 +74,15 @@ public class PaymentRetryService {
             }
         });
 
-        log.info("결제 재시도 요청. partyCycleId={}, partyId={}, adminId={}", partyCycleId, partyId, adminId);
+        log.info("결제 재시도 요청. partyCycleId={}, partyId={}, adminId={}, requestedAt={}",
+                partyCycleId, partyId, adminId, requestedAt);
     }
 
-    private String buildPayload(Long partyCycleId, int cycleNo) {
-        return "{\"partyCycleId\":" + partyCycleId + ",\"cycleNo\":" + cycleNo + "}";
+    private String buildPayload(Long partyCycleId, int cycleNo, Long partyId, Long adminId, LocalDateTime requestedAt) {
+        return "{\"partyCycleId\":" + partyCycleId
+                + ",\"cycleNo\":" + cycleNo
+                + ",\"partyId\":" + partyId
+                + ",\"adminId\":" + adminId
+                + ",\"requestedAt\":\"" + requestedAt + "\"}";
     }
 }

--- a/src/main/java/pbl2/sub119/backend/toss/controller/PaymentController.java
+++ b/src/main/java/pbl2/sub119/backend/toss/controller/PaymentController.java
@@ -6,11 +6,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pbl2.sub119.backend.auth.aop.Auth;
 import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.payment.dto.response.PaymentHistoryItem;
+import pbl2.sub119.backend.payment.service.PaymentHistoryQueryService;
 import pbl2.sub119.backend.toss.controller.docs.PaymentDocs;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
 import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
 import pbl2.sub119.backend.toss.service.BillingKeyService;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -19,12 +22,8 @@ import java.util.Map;
 public class PaymentController implements PaymentDocs {
 
     private final BillingKeyService billingKeyService;
+    private final PaymentHistoryQueryService paymentHistoryQueryService;
 
-    /**
-     * 빌링키 발급
-     * 프론트에서 토스 결제창 띄운 후 authKey 받아서 여기로 전달
-     * POST /api/v1/payments/billing/authorize
-     */
     @PostMapping("/billing/authorize")
     public ResponseEntity<Void> issueBillingKey(
             @Auth final Accessor accessor,
@@ -54,4 +53,13 @@ public class PaymentController implements PaymentDocs {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/me/history")
+    public ResponseEntity<List<PaymentHistoryItem>> getMyPaymentHistory(
+            @Auth final Accessor accessor,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(
+                paymentHistoryQueryService.getMyPaymentHistory(accessor.getUserId(), page, size)
+        );
+    }
 }

--- a/src/main/java/pbl2/sub119/backend/toss/controller/docs/PaymentDocs.java
+++ b/src/main/java/pbl2/sub119/backend/toss/controller/docs/PaymentDocs.java
@@ -11,11 +11,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import pbl2.sub119.backend.auth.aop.Auth;
 import pbl2.sub119.backend.auth.entity.Accessor;
+import pbl2.sub119.backend.payment.dto.response.PaymentHistoryItem;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
 import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
 
+import java.util.List;
 import java.util.Map;
 
 @Tag(
@@ -144,5 +147,32 @@ public interface PaymentDocs {
             @Parameter(hidden = true) @Auth Accessor accessor,
             @Parameter(description = "새 카드 authKey", required = true)
             @Valid @RequestBody BillingKeyIssueRequest request
+    );
+
+    @Operation(
+            summary = "내 결제내역 조회",
+            description = """
+                    현재 로그인한 사용자의 결제내역을 최신순으로 조회합니다.
+                    page(0-based), size 파라미터로 페이징을 제어합니다.
+                    실패 건은 failureReason / failureCode 필드를 포함합니다.
+                    상태값: PAYMENT_PENDING / PROCESSING / PAID / FAILED / CANCELLED
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "조회 성공"
+                    ),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "인증 필요",
+                            content = @Content
+                    )
+            }
+    )
+    @GetMapping("/me/history")
+    ResponseEntity<List<PaymentHistoryItem>> getMyPaymentHistory(
+            @Parameter(hidden = true) @Auth Accessor accessor,
+            @Parameter(description = "페이지 번호 (0-based, 기본값 0)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 (기본값 20, 최대 100)") @RequestParam(defaultValue = "20") int size
     );
 }

--- a/src/main/java/pbl2/sub119/backend/user/service/UserService.java
+++ b/src/main/java/pbl2/sub119/backend/user/service/UserService.java
@@ -38,9 +38,9 @@ public class UserService {
             throw new IllegalArgumentException("이미 회원가입이 완료된 회원입니다.");
         }
 
-//        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
-//            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
-//        }
+        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
+            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
+        }
 
         validateNicknameDuplication(user.getId(), request.nickname());
         validatePhoneNumberDuplication(user.getId(), request.phoneNumber());
@@ -59,7 +59,7 @@ public class UserService {
                 UserStatus.ACTIVE.name()
         );
 
-        // phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
+        phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
 
         final UserEntity updatedUser = findActiveUserOrThrow(user.getId());
         return UserSignUpResponse.from(updatedUser);

--- a/src/main/java/pbl2/sub119/backend/user/service/UserService.java
+++ b/src/main/java/pbl2/sub119/backend/user/service/UserService.java
@@ -38,9 +38,9 @@ public class UserService {
             throw new IllegalArgumentException("이미 회원가입이 완료된 회원입니다.");
         }
 
-        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
-            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
-        }
+//        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
+//            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
+//        }
 
         validateNicknameDuplication(user.getId(), request.nickname());
         validatePhoneNumberDuplication(user.getId(), request.phoneNumber());
@@ -59,7 +59,7 @@ public class UserService {
                 UserStatus.ACTIVE.name()
         );
 
-        phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
+        // phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
 
         final UserEntity updatedUser = findActiveUserOrThrow(user.getId());
         return UserSignUpResponse.from(updatedUser);

--- a/src/main/resources/mapper/partyprovision/PartyProvisionMapper.xml
+++ b/src/main/resources/mapper/partyprovision/PartyProvisionMapper.xml
@@ -40,7 +40,131 @@
         updated_at
     </sql>
 
-    <!-- 48시간 초과 → 파티 해체 -->
+    <!-- 파티 기준 현재 운영 정보 단건 조회 -->
+    <select id="findByPartyId" resultMap="partyOperationResultMap">
+        SELECT
+        <include refid="partyOperationColumns"/>
+        FROM party_operation
+        WHERE party_id = #{partyId}
+        LIMIT 1
+    </select>
+
+    <!-- 운영 상태 갱신 시 동시성 제어 -->
+    <select id="findByPartyIdForUpdate" resultMap="partyOperationResultMap">
+        SELECT
+        <include refid="partyOperationColumns"/>
+        FROM party_operation
+        WHERE party_id = #{partyId}
+        LIMIT 1
+        FOR UPDATE
+    </select>
+
+    <!-- 파티장이 파티 운영 정보 최초 생성 -->
+    <insert id="insert"
+            parameterType="pbl2.sub119.backend.party.provision.entity.PartyProvision"
+            useGeneratedKeys="true"
+            keyProperty="id">
+        INSERT INTO party_operation
+        (
+            party_id,
+            operation_type,
+            operation_status,
+            invite_value,
+            shared_account_email,
+            shared_account_password_encrypted,
+            operation_guide,
+            operation_started_at,
+            operation_completed_at,
+            last_reset_at,
+            created_at,
+            updated_at
+        )
+        VALUES
+            (
+                #{partyId},
+                #{operationType},
+                #{operationStatus},
+                #{inviteValue},
+                #{sharedAccountEmail},
+                #{sharedAccountPasswordEncrypted},
+                #{operationGuide},
+                #{operationStartedAt},
+                #{operationCompletedAt},
+                #{lastResetAt},
+                #{createdAt},
+                #{updatedAt}
+            )
+    </insert>
+
+    <!-- 파티장이 운영 정보 등록 및 수정 -->
+    <update id="updateSetup">
+        UPDATE party_operation
+        SET
+            operation_type = #{operationType},
+            operation_status = #{operationStatus},
+            invite_value = #{inviteValue},
+            shared_account_email = #{sharedAccountEmail},
+            shared_account_password_encrypted = #{sharedAccountPasswordEncrypted},
+            operation_guide = #{operationGuide},
+            operation_started_at = #{operationStartedAt},
+            operation_completed_at = NULL,
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 멤버 진행 상황에 따라 운영 상태만 갱신 -->
+    <update id="updateStatus">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 동시 confirm 상황에서 ACTIVE인 상태 IN_PROGRESS로 되돌리는 문제 방지 -->
+    <update id="updateStatusIfNotActive">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+          AND operation_status &lt;&gt; 'ACTIVE'
+    </update>
+
+    <!-- 전원 완료 시 운영 상태 ACTIVE + 완료 시각 기록 -->
+    <update id="updateStatusAndCompletedAt">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            operation_completed_at = #{operationCompletedAt},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 재초대/비밀번호 변경 등으로 운영 재설정 처리 -->
+    <update id="markResetRequired">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            last_reset_at = #{lastResetAt},
+            operation_completed_at = NULL,
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- cycle start 이후 멤버 변경 발생 시 운영 재설정 처리 -->
+    <update id="updateCycleStartResetState">
+        UPDATE party_operation
+        SET
+            operation_status = #{operationStatus},
+            operation_started_at = #{operationStartedAt},
+            operation_completed_at = NULL,
+            last_reset_at = #{lastResetAt},
+            updated_at = #{updatedAt}
+        WHERE id = #{id}
+    </update>
+
+    <!-- 48시간 초과 -> 파티 해체 -->
     <select id="findTimedOutProvisions" resultMap="partyOperationResultMap">
         SELECT
         <include refid="partyOperationColumns"/>
@@ -50,7 +174,7 @@
         AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= 48
     </select>
 
-    <!-- 24시간 → 파티장 리마인드 + 파티원 지연 안내 (이미 알림 발송된 파티 제외) -->
+    <!-- 24시간 -> 파티장 리마인드 + 파티원 지연 안내 (이미 알림 발송된 파티 제외) -->
     <select id="findHostProvisionAt24hDue" resultMap="partyOperationResultMap">
         SELECT
             po.id,
@@ -67,18 +191,18 @@
             po.created_at,
             po.updated_at
         FROM party_operation po
-        INNER JOIN party p ON p.id = po.party_id
+                 INNER JOIN party p ON p.id = po.party_id
         WHERE po.operation_status != 'ACTIVE'
-        AND po.operation_started_at IS NULL
-        AND p.operation_status != 'TERMINATED'
-        AND TIMESTAMPDIFF(HOUR, po.created_at, NOW()) >= #{elapsedHours}
-        AND TIMESTAMPDIFF(HOUR, po.created_at, NOW()) <![CDATA[<]]> #{elapsedHours} + 1
-        AND NOT EXISTS (
+          AND po.operation_started_at IS NULL
+          AND p.operation_status != 'TERMINATED'
+          AND TIMESTAMPDIFF(HOUR, po.created_at, NOW()) >= #{elapsedHours}
+          AND TIMESTAMPDIFF(HOUR, po.created_at, NOW()) <![CDATA[<]]> #{elapsedHours} + 1
+          AND NOT EXISTS (
             SELECT 1 FROM notification n
             WHERE n.party_id = po.party_id
-            AND n.user_id = p.host_user_id
-            AND n.type = 'HOST_PROVISION_REMINDER'
-        )
+          AND n.user_id = p.host_user_id
+          AND n.type = 'HOST_PROVISION_REMINDER'
+            )
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/payment/PartyCycleMapper.xml
+++ b/src/main/resources/mapper/payment/PartyCycleMapper.xml
@@ -118,6 +118,15 @@
           AND status IN ('PAYMENT_PENDING', 'PROCESSING')
     </update>
 
+    <!-- 초기 결제(cycle_no=1)가 FAILED 상태인지 확인 — 반복회차 실패는 제외 -->
+    <select id="existsFailedInitialCycle" resultType="boolean">
+        SELECT CASE WHEN COUNT(1) > 0 THEN TRUE ELSE FALSE END
+        FROM party_cycle
+        WHERE party_id = #{partyId}
+          AND cycle_no  = 1
+          AND status    = 'FAILED'
+    </select>
+
     <insert id="save"
             parameterType="pbl2.sub119.backend.payment.entity.PartyCycle"
             useGeneratedKeys="true"

--- a/src/main/resources/mapper/payment/UserPaymentHistoryQueryMapper.xml
+++ b/src/main/resources/mapper/payment/UserPaymentHistoryQueryMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="pbl2.sub119.backend.payment.mapper.UserPaymentHistoryQueryMapper">
+
+    <resultMap id="PaymentHistoryItemMap" type="pbl2.sub119.backend.payment.dto.response.PaymentHistoryItem">
+        <result property="partyId"       column="party_id"/>
+        <result property="partyCycleId"  column="party_cycle_id"/>
+        <result property="serviceName"   column="service_name"/>
+        <result property="amount"        column="amount"/>
+        <result property="status"        column="status"/>
+        <result property="paidAt"        column="paid_at"/>
+        <result property="failedAt"      column="failed_at"/>
+        <result property="failureReason" column="failure_reason"/>
+        <result property="failureCode"   column="failure_code"/>
+        <result property="createdAt"     column="created_at"/>
+    </resultMap>
+
+    <select id="findByUserId" resultMap="PaymentHistoryItemMap">
+        SELECT
+            pcmp.party_id,
+            pcmp.party_cycle_id,
+            sp.service_name,
+            pcmp.amount,
+            pcmp.status,
+            pcmp.paid_at,
+            pcmp.failed_at,
+            pcmp.failure_reason,
+            pcmp.failure_code,
+            pcmp.created_at
+        FROM party_cycle_member_payment pcmp
+        INNER JOIN party p ON p.id = pcmp.party_id
+        LEFT JOIN sub_product sp ON sp.id = p.product_id
+        WHERE pcmp.user_id = #{userId}
+        ORDER BY pcmp.created_at DESC
+        LIMIT #{size} OFFSET #{offset}
+    </select>
+
+</mapper>


### PR DESCRIPTION
배경
•초기 결제 시점이 운영 정책과 맞지 않던 부분 정리 필요
•초기결제 실패 복구 경로를 자동이 아닌 어드민 명시 액션으로 고정 필요
•사용자 결제 이력 조회 API 부재

주요 변경
•빌링키 발급 이벤트에서 초기결제 트리거 제거 (BillingKeyIssuedEventListener)
•setupProvision() 완료 시점 이벤트 발행으로 초기결제 트리거 일원화
•초기 사이클(cycle_no=1) FAILED 이력 존재 시 provision 재호출 자동 재트리거 차단
•결제 실패 복구는 admin retry API 경로만 허용
•결제 재시도 감사로그 강화 (partyId, adminId, requestedAt payload 기록)
•내 결제내역 조회 API 추가
◦GET /api/v1/payments/me/history?page=0&size=20
◦최신순 조회, 실패 사유/코드 포함
◦DTO/Mapper/XML/Service/Controller/Swagger 문서 반영

정책 요약
•빌링키 발급만으로 결제 실행 안 함
•provision setup 완료 시에만 초기결제 실행 시도
•초기결제 FAILED 이후 자동 재결제 금지
•실패 복구는 POST /api/v1/admin/payments/cycles/{partyCycleId}/retry만 허용

수동 검증
•빌링키 발급 단독 시 결제 미실행 확인
•provision setup 시 초기결제 실행 확인
•초기결제 FAILED 후 provision 재호출 시 자동 재실행 차단 확인
•admin retry로만 재결제 실행 확인
•/payments/me/history 정상 응답 확인
•./gradlew compileJava 성공

영향 범위
•초기결제 트리거/실패 복구/결제내역 조회 영역
•reset/멤버 스위칭 로직과 직접 결합 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결제 내역 조회 API 추가: 사용자가 본인의 결제 기록을 확인할 수 있는 새로운 엔드포인트 추가
  * 관리자 결제 재시도 기능: 실패한 결제에 대해 명시적인 관리자 조치만 허용하며, 감사 로그에 상세 정보 기록

* **Bug Fixes**
  * 초기 결제 실패 시 자동 재시도 방지: 이미 실패한 결제 사이클이 존재할 경우 중복 재시도 생성 방지
  
* **Documentation**
  * API 문서 업데이트: 결제 재시도 및 자동 결제 트리거 정책 명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->