### PR TITLE
fix: RUNNING 사이클 탈퇴 예약 창 마감을 billingDueAt+1개월로 계산

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/cycle/service/SubscriptionCycleWindowValidator.java
+++ b/src/main/java/pbl2/sub119/backend/party/cycle/service/SubscriptionCycleWindowValidator.java
@@ -30,15 +30,18 @@ public class SubscriptionCycleWindowValidator {
             throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
         }
 
-        // 종료일이 없으면 주기 정보가 완성되지 않은 상태로 보고 차단
-        if (cycle.getEndAt() == null) {
+        // 다음 결제 사이클이 이미 생성된 경우(PAYMENT_PENDING) — 결제 진행 구간으로 보고 차단
+        if (cycle.getStatus() != PartyCycleStatus.RUNNING) {
             throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
         }
 
-        final LocalDateTime now = LocalDateTime.now();
+        // RUNNING 사이클의 endAt은 다음 회차 결제 성공 시 채워지므로 null이 정상
+        // endAt이 없으면 billingDueAt + 1개월(다음 결제 예정일)을 마감으로 사용
+        final LocalDateTime deadline = cycle.getEndAt() != null
+                ? cycle.getEndAt()
+                : cycle.getBillingDueAt().plusMonths(1);
 
-        // 종료 시각 이상이면 탈퇴 예약 불가
-        if (!now.isBefore(cycle.getEndAt())) {
+        if (!LocalDateTime.now().isBefore(deadline)) {
             throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
         }
     }

--- a/src/main/java/pbl2/sub119/backend/party/cycle/service/SubscriptionCycleWindowValidator.java
+++ b/src/main/java/pbl2/sub119/backend/party/cycle/service/SubscriptionCycleWindowValidator.java
@@ -37,9 +37,15 @@ public class SubscriptionCycleWindowValidator {
 
         // RUNNING 사이클의 endAt은 다음 회차 결제 성공 시 채워지므로 null이 정상
         // endAt이 없으면 billingDueAt + 1개월(다음 결제 예정일)을 마감으로 사용
-        final LocalDateTime deadline = cycle.getEndAt() != null
-                ? cycle.getEndAt()
-                : cycle.getBillingDueAt().plusMonths(1);
+        final LocalDateTime billingDueAt = cycle.getBillingDueAt();
+                final LocalDateTime deadline;
+                if (cycle.getEndAt() != null) {
+                    deadline = cycle.getEndAt();
+                } else if (billingDueAt != null) {
+                    deadline = billingDueAt.plusMonths(1);
+                } else {
+                    throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
+                }
 
         if (!LocalDateTime.now().isBefore(deadline)) {
             throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 구독 탈퇴 예약 차단 로직을 개선했습니다. 이제 활성화된 구독 주기에서만 탈퇴 예약이 차단되며, 주기 종료 시점 계산이 더 정확해졌습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->