### PR TITLE
feat: 결원 파티 노출 수정 및 입장자 SWITCH_WAITING 전환, 탈퇴 취소 시 재매칭 연결

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/join/service/PartyJoinService.java
+++ b/src/main/java/pbl2/sub119/backend/party/join/service/PartyJoinService.java
@@ -92,4 +92,51 @@ public class PartyJoinService {
                 userId
         );
     }
+
+    // 결원 파티 참여 — current_member_count 증가 없이 SWITCH_WAITING으로 자리 확정 예약
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void joinVacancyParty(final Long partyId, final Long userId) {
+        final Party party = partyMapper.findByIdForUpdate(partyId);
+        if (party == null) {
+            throw new PartyException(ErrorCode.PARTY_NOT_FOUND);
+        }
+
+        if (party.getRecruitStatus() != RecruitStatus.RECRUITING) {
+            throw new PartyException(ErrorCode.PARTY_NOT_RECRUITING);
+        }
+
+        // 이미 SWITCH_WAITING 멤버가 있으면 자리 없음 (동시 접근 방지)
+        if (!partyMemberMapper.findSwitchWaitingMembers(partyId).isEmpty()) {
+            throw new PartyException(ErrorCode.PARTY_FULL);
+        }
+
+        final PartyMember existing = partyMemberMapper.findByPartyIdAndUserId(partyId, userId);
+        if (existing != null
+                && existing.getStatus() != PartyMemberStatus.LEFT
+                && existing.getStatus() != PartyMemberStatus.REMOVED) {
+            throw new PartyException(ErrorCode.PARTY_ALREADY_JOINED);
+        }
+
+        final LocalDateTime now = LocalDateTime.now();
+        final PartyMember newMember = PartyMember.builder()
+                .partyId(partyId)
+                .userId(userId)
+                .role(PartyRole.MEMBER)
+                .status(PartyMemberStatus.SWITCH_WAITING)
+                .joinedAt(now)
+                .build();
+
+        partyMemberMapper.insertPartyMember(newMember);
+
+        // 자리 확정 예약 → 더 이상 결원 모집 불가
+        partyMapper.updateRecruitStatus(partyId, RecruitStatus.FULL);
+
+        partyHistoryService.saveHistory(
+                partyId,
+                newMember.getId(),
+                PartyHistoryEventType.MEMBER_JOINED,
+                "{\"userId\":" + userId + "}",
+                userId
+        );
+    }
 }

--- a/src/main/java/pbl2/sub119/backend/party/leave/service/PartyLeaveService.java
+++ b/src/main/java/pbl2/sub119/backend/party/leave/service/PartyLeaveService.java
@@ -1,16 +1,23 @@
 package pbl2.sub119.backend.party.leave.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.common.enumerated.PartyMemberStatus;
 import pbl2.sub119.backend.common.error.ErrorCode;
+import pbl2.sub119.backend.notification.event.event.MemberAutoRematchStartedEvent;
+import pbl2.sub119.backend.party.common.entity.MatchWaitingQueue;
 import pbl2.sub119.backend.party.common.entity.Party;
 import pbl2.sub119.backend.party.common.entity.PartyMember;
+import pbl2.sub119.backend.party.common.enumerated.MatchWaitingStatus;
 import pbl2.sub119.backend.party.common.enumerated.PartyHistoryEventType;
 import pbl2.sub119.backend.party.common.enumerated.PartyRole;
+import pbl2.sub119.backend.party.common.enumerated.RecruitStatus;
 import pbl2.sub119.backend.party.common.enumerated.VacancyType;
+import pbl2.sub119.backend.party.common.mapper.MatchWaitingQueueMapper;
 import pbl2.sub119.backend.party.common.service.PartyHistoryService;
 import pbl2.sub119.backend.party.cycle.service.SubscriptionCycleWindowValidator;
 import pbl2.sub119.backend.party.common.exception.PartyException;
@@ -27,6 +34,8 @@ public class PartyLeaveService {
     private final PartyMemberMapper partyMemberMapper;
     private final PartyHistoryService partyHistoryService;
     private final SubscriptionCycleWindowValidator subscriptionCycleWindowValidator;
+    private final MatchWaitingQueueMapper matchWaitingQueueMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     // 다음 결제일 기준 탈퇴 예약
     @Transactional
@@ -60,6 +69,7 @@ public class PartyLeaveService {
                 member.getRole() == PartyRole.HOST ? VacancyType.HOST : VacancyType.MEMBER;
 
         partyMapper.updateVacancyType(partyId, vacancyType);
+        partyMapper.updateRecruitStatus(partyId, RecruitStatus.RECRUITING);
 
         final PartyMember updatedMember = partyMemberMapper.findByPartyIdAndUserId(partyId, userId);
 
@@ -100,30 +110,65 @@ public class PartyLeaveService {
             throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
         }
 
-        final int updated = partyMemberMapper.clearLeaveReserved(partyId, userId);
-        if (updated == 0) {
-            throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
-        }
-
-        final List<PartyMember> reservedMembers = partyMemberMapper.findLeaveReservedMembers(partyId);
         final List<PartyMember> switchWaitingMembers = partyMemberMapper.findSwitchWaitingMembers(partyId);
 
-        if (reservedMembers.isEmpty() && switchWaitingMembers.isEmpty()) {
-            partyMapper.updateVacancyType(partyId, VacancyType.NONE);
+        if (switchWaitingMembers.isEmpty()) {
+            // Case A: 입장 대기자 없음 → 탈퇴 예약 취소
+            final int updated = partyMemberMapper.clearLeaveReserved(partyId, userId);
+            if (updated == 0) {
+                throw new PartyException(ErrorCode.PARTY_LEAVE_NOT_ALLOWED);
+            }
+
+            final List<PartyMember> reservedMembers = partyMemberMapper.findLeaveReservedMembers(partyId);
+            if (reservedMembers.isEmpty()) {
+                partyMapper.updateVacancyType(partyId, VacancyType.NONE);
+                final int occupiedCount = partyMemberMapper.countOccupiedMembers(partyId);
+                partyMapper.updateRecruitStatus(partyId,
+                        occupiedCount >= party.getCapacity() ? RecruitStatus.FULL : RecruitStatus.RECRUITING);
+            } else {
+                final boolean hasHostReservation = reservedMembers.stream()
+                        .anyMatch(m -> m.getRole() == PartyRole.HOST);
+                partyMapper.updateVacancyType(partyId, hasHostReservation ? VacancyType.HOST : VacancyType.MEMBER);
+            }
+
+            partyHistoryService.saveHistory(
+                    partyId,
+                    member.getId(),
+                    PartyHistoryEventType.LEAVE_RESERVATION_CANCELED,
+                    "{\"userId\":" + userId + "}",
+                    userId
+            );
         } else {
-            final boolean hasHostReservation = reservedMembers.stream()
-                    .anyMatch(reservedMember -> reservedMember.getRole() == PartyRole.HOST);
+            // Case B: 입장 대기자 있음 → 탈퇴 강제 실행 + 탈퇴자 재매칭
+            partyMemberMapper.updateStatusAndLeftAt(member.getId(), PartyMemberStatus.LEFT);
+            requeueMember(party.getProductId(), userId);
+            eventPublisher.publishEvent(new MemberAutoRematchStartedEvent(partyId, List.of(userId)));
 
-            partyMapper.updateVacancyType(partyId, hasHostReservation ? VacancyType.HOST : VacancyType.MEMBER);
+            final int occupiedCount = partyMemberMapper.countOccupiedMembers(partyId);
+            partyMapper.updateCurrentMemberCount(partyId, occupiedCount);
+            partyMapper.updateVacancyType(partyId, VacancyType.NONE);
+            partyMapper.updateRecruitStatus(partyId, RecruitStatus.FULL);
+
+            partyHistoryService.saveHistory(
+                    partyId,
+                    member.getId(),
+                    PartyHistoryEventType.MEMBER_LEFT,
+                    "{\"userId\":" + userId + "}",
+                    userId
+            );
         }
+    }
 
-        partyHistoryService.saveHistory(
-                partyId,
-                member.getId(),
-                PartyHistoryEventType.LEAVE_RESERVATION_CANCELED,
-                "{\"userId\":" + userId + "}",
-                userId
-        );
+    private void requeueMember(final String productId, final Long userId) {
+        final LocalDateTime now = LocalDateTime.now();
+        matchWaitingQueueMapper.insertIfAbsent(MatchWaitingQueue.builder()
+                .productId(productId)
+                .userId(userId)
+                .status(MatchWaitingStatus.WAITING)
+                .requestedAt(now)
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
     }
 
     // 파티장이 탈퇴 예약 멤버 목록 조회

--- a/src/main/java/pbl2/sub119/backend/party/vacancy/service/PartyVacancyCommandService.java
+++ b/src/main/java/pbl2/sub119/backend/party/vacancy/service/PartyVacancyCommandService.java
@@ -29,7 +29,7 @@ public class PartyVacancyCommandService {
             throw new PartyException(ErrorCode.PARTY_NOT_FOUND);
         }
 
-        partyJoinService.joinParty(partyId, userId);
+        partyJoinService.joinVacancyParty(partyId, userId);
 
         final SubProductResponse product = subProductService.getProduct(party.getProductId());
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 파티 공석 입장 시스템 추가로 사용자가 대기 상태로 가득 찬 파티에 참여 가능
  * 멤버 탈퇴 시 자동 재매칭 기능 구현으로 파티 구성원 자동 조정
  * 파티 모집 상태 동적 관리로 공석 상황에 따른 모집 상태 자동 업데이트

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/112)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->