### PR TITLE
[BankAccount] 계좌 인증 flow 분기(파티/마이페이지) 및 정산계좌 활성/해제 시퀀스 정비

### DIFF
--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/BankController.java
@@ -6,11 +6,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.util.UriComponentsBuilder;
 import pbl2.sub119.backend.auth.aop.Auth;
@@ -21,6 +23,7 @@ import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountReq
 import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
 import pbl2.sub119.backend.bankaccounts.dto.response.BankAuthorizeUrlResponse;
 import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
+import pbl2.sub119.backend.bankaccounts.enums.BankAuthFlow;
 import pbl2.sub119.backend.bankaccounts.service.BankAuthStateStore;
 import pbl2.sub119.backend.bankaccounts.service.BankService;
 import pbl2.sub119.backend.common.exception.BusinessException;
@@ -57,18 +60,7 @@ public class BankController implements BankDocs {
             @RequestParam String productId
     ) {
         String state = bankAuthStateStore.create(accessor.getUserId(), productId);
-
-        String authorizeUrl = UriComponentsBuilder
-                .fromHttpUrl(kftcBaseUrl + "/oauth/2.0/authorize")
-                .queryParam("response_type", "code")
-                .queryParam("client_id", kftcClientId)
-                .queryParam("redirect_uri", kftcRedirectUrl)
-                .queryParam("scope", "login inquiry")
-                .queryParam("state", state)
-                .queryParam("auth_type", "0")
-                .toUriString();
-
-        return redirect(authorizeUrl);
+        return redirect(buildKftcAuthorizeUrl(state));
     }
 
     @Override
@@ -82,48 +74,37 @@ public class BankController implements BankDocs {
 
         if (authState == null) {
             String invalidStateUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl)
-                    .path("/party/create/0/host/account-register")
                     .queryParam("bankAuthSuccess", false)
                     .queryParam("message", "유효하지 않은 인증 요청입니다.")
                     .toUriString();
-
             return redirect(invalidStateUrl);
         }
 
-        String redirectBaseUrl = UriComponentsBuilder.fromUriString(frontendBaseUrl)
-                .path("/party/create/{productId}/host/account-register")
-                .buildAndExpand(authState.getProductId())
-                .toUriString();
+        String redirectBaseUrl = resolveRedirectBaseUrl(authState);
 
         try {
             bankService.registerAccount(authState.getUserId(), code);
             bankAuthStateStore.remove(state);
 
-            String successUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+            return redirect(UriComponentsBuilder.fromUriString(redirectBaseUrl)
                     .queryParam("bankAuthSuccess", true)
-                    .toUriString();
-
-            return redirect(successUrl);
+                    .toUriString());
 
         } catch (BusinessException e) {
             bankAuthStateStore.remove(state);
 
-            String failUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+            return redirect(UriComponentsBuilder.fromUriString(redirectBaseUrl)
                     .queryParam("bankAuthSuccess", false)
                     .queryParam("message", e.getErrorCode().getMessage())
-                    .toUriString();
-
-            return redirect(failUrl);
+                    .toUriString());
 
         } catch (Exception e) {
             bankAuthStateStore.remove(state);
 
-            String failUrl = UriComponentsBuilder.fromUriString(redirectBaseUrl)
+            return redirect(UriComponentsBuilder.fromUriString(redirectBaseUrl)
                     .queryParam("bankAuthSuccess", false)
                     .queryParam("message", BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED.getMessage())
-                    .toUriString();
-
-            return redirect(failUrl);
+                    .toUriString());
         }
     }
 
@@ -138,6 +119,13 @@ public class BankController implements BankDocs {
     }
 
     @Override
+    @DeleteMapping("/settlement")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteSettlementAccount(@Auth final Accessor accessor) {
+        bankService.deactivateSettlementAccount(accessor.getUserId());
+    }
+
+    @Override
     @GetMapping("/accounts")
     public List<BankAccountSummaryResponse> getAccounts(@Auth final Accessor accessor) {
         return bankService.getAccounts(accessor.getUserId());
@@ -149,12 +137,6 @@ public class BankController implements BankDocs {
         return bankService.getPrimaryAccount(accessor.getUserId());
     }
 
-    private ResponseEntity<Void> redirect(String url) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create(url));
-        return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
-    }
-
     @Override
     @GetMapping("/authorize-url")
     public BankAuthorizeUrlResponse authorizeUrl(
@@ -162,8 +144,30 @@ public class BankController implements BankDocs {
             @RequestParam String productId
     ) {
         String state = bankAuthStateStore.create(accessor.getUserId(), productId);
+        return new BankAuthorizeUrlResponse(buildKftcAuthorizeUrl(state));
+    }
 
-        String authorizeUrl = UriComponentsBuilder
+    @Override
+    @GetMapping("/authorize-url/mypage")
+    public BankAuthorizeUrlResponse authorizeUrlMyPage(@Auth final Accessor accessor) {
+        String state = bankAuthStateStore.createForMyPage(accessor.getUserId());
+        return new BankAuthorizeUrlResponse(buildKftcAuthorizeUrl(state));
+    }
+
+    private String resolveRedirectBaseUrl(BankAuthState authState) {
+        if (authState.getFlow() == BankAuthFlow.MY_PAGE) {
+            return UriComponentsBuilder.fromUriString(frontendBaseUrl)
+                    .path("/mypage/account-register")
+                    .toUriString();
+        }
+        return UriComponentsBuilder.fromUriString(frontendBaseUrl)
+                .path("/party/create/{productId}/host/account-register")
+                .buildAndExpand(authState.getProductId())
+                .toUriString();
+    }
+
+    private String buildKftcAuthorizeUrl(String state) {
+        return UriComponentsBuilder
                 .fromHttpUrl(kftcBaseUrl + "/oauth/2.0/authorize")
                 .queryParam("response_type", "code")
                 .queryParam("client_id", kftcClientId)
@@ -172,7 +176,11 @@ public class BankController implements BankDocs {
                 .queryParam("state", state)
                 .queryParam("auth_type", "0")
                 .toUriString();
+    }
 
-        return new BankAuthorizeUrlResponse(authorizeUrl);
+    private ResponseEntity<Void> redirect(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setLocation(URI.create(url));
+        return ResponseEntity.status(HttpStatus.FOUND).headers(headers).build();
     }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
@@ -43,7 +43,11 @@ public interface BankDocs {
 
     @Operation(
             summary = "금융결제원 계좌 연결 콜백",
-            description = "OAuth 인가코드(code)와 state를 받아 연결 계좌 후보를 저장한 뒤 프론트 계좌등록 페이지로 리다이렉트합니다."
+            description = """
+                    OAuth 인가코드(code)와 state를 받아 연결 계좌를 저장한 뒤 flow에 맞는 프론트 경로로 리다이렉트합니다.
+                    - PARTY_CREATE flow: /party/create/{productId}/host/account-register 로 복귀
+                    - MY_PAGE flow: /mypage/account-register 로 복귀
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "302", description = "프론트 계좌등록 페이지로 리다이렉트",
@@ -63,8 +67,17 @@ public interface BankDocs {
     );
 
     @Operation(
-            summary = "정산/환불 계좌 등록",
-            description = "연결된 계좌(fintech_use_num)를 기준으로 정산계좌 메타데이터를 저장하고 실명검증 상태를 반영합니다."
+            summary = "정산 계좌 등록 / 교체",
+            description = """
+                    금융결제원 인증으로 연결된 계좌(fintech_use_num)를 활성 정산계좌로 설정합니다.
+
+                    시퀀스: 금융결제원 재인증 → GET /bank/accounts 로 목록 확인 → 이 API로 계좌 선택
+                    - accountType은 반드시 SETTLEMENT 이어야 합니다. 그 외 값은 400(BANK002)으로 거부됩니다.
+                    - isPrimary 필드는 요청에 포함하지 않습니다. 등록된 계좌는 항상 대표 계좌가 됩니다.
+                    - 기존 활성 정산계좌(account_type=SETTLEMENT, is_primary=true)가 비활성화되고, \
+                    선택한 계좌 1건만 활성 정산계좌로 확정됩니다. 나머지 연결 계좌 row는 유지됩니다.
+                    - 전체 처리는 단일 트랜잭션 내에서 원자적으로 수행됩니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "정산계좌 등록 성공",
@@ -81,6 +94,26 @@ public interface BankDocs {
     String registerSettlementAccount(
             @Parameter(hidden = true) @Auth Accessor accessor,
             @Valid @RequestBody RegisterSettlementAccountRequest request
+    );
+
+    @Operation(
+            summary = "활성 정산계좌 해제",
+            description = """
+                    현재 활성 정산계좌(account_type=SETTLEMENT, is_primary=true)를 비활성화합니다.
+                    - 연결 계좌 row는 삭제되지 않고 목록에 유지됩니다.
+                    - 해제 후 POST /bank/settlement 로 다시 계좌를 선택할 수 있습니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "정산계좌 해제 성공",
+                    content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "활성 정산계좌 없음 (BANK006)",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    void deleteSettlementAccount(
+            @Parameter(hidden = true) @Auth Accessor accessor
     );
 
     @Operation(
@@ -114,12 +147,12 @@ public interface BankDocs {
     );
 
     @Operation(
-            summary = "금융결제원 계좌 연결 인증 URL 조회",
+            summary = "[파티 생성용] 금융결제원 계좌 연결 인증 URL 조회",
             description = """
-                프론트가 axios로 호출하여 오픈뱅킹 authorize URL을 응답받습니다.
-                이 API는 Authorization 헤더 기반 인증을 통과한 뒤 state를 생성/저장하고,
-                프론트는 응답받은 authorizeUrl로 window.location.href 이동하면 됩니다.
-                """
+                    파티 생성 시 계좌 연결을 위한 오픈뱅킹 authorize URL을 반환합니다. productId 필수.
+                    callback 후 /party/create/{productId}/host/account-register 로 복귀합니다.
+                    프론트는 응답받은 authorizeUrl로 window.location.href 이동하면 됩니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "오픈뱅킹 authorize URL 조회 성공",
@@ -133,5 +166,21 @@ public interface BankDocs {
             @RequestParam String productId
     );
 
-
+    @Operation(
+            summary = "[마이페이지용] 금융결제원 계좌 재인증 URL 조회",
+            description = """
+                    마이페이지에서 정산계좌 변경을 위한 오픈뱅킹 authorize URL을 반환합니다. productId 불필요.
+                    callback 후 /mypage/account-register 로 복귀합니다.
+                    프론트는 응답받은 authorizeUrl로 window.location.href 이동하면 됩니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "오픈뱅킹 authorize URL 조회 성공",
+                    content = @Content(schema = @Schema(implementation = BankAuthorizeUrlResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    BankAuthorizeUrlResponse authorizeUrlMyPage(
+            @Parameter(hidden = true) @Auth Accessor accessor
+    );
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthState.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthState.java
@@ -1,12 +1,25 @@
 package pbl2.sub119.backend.bankaccounts.dto;
 
-
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import pbl2.sub119.backend.bankaccounts.enums.BankAuthFlow;
 
 @Getter
-@AllArgsConstructor
 public class BankAuthState {
-    private Long userId;
-    private String productId;
+    private final Long userId;
+    private final BankAuthFlow flow;
+    private final String productId;
+
+    private BankAuthState(Long userId, BankAuthFlow flow, String productId) {
+        this.userId = userId;
+        this.flow = flow;
+        this.productId = productId;
+    }
+
+    public static BankAuthState forPartyCreate(Long userId, String productId) {
+        return new BankAuthState(userId, BankAuthFlow.PARTY_CREATE, productId);
+    }
+
+    public static BankAuthState forMyPage(Long userId) {
+        return new BankAuthState(userId, BankAuthFlow.MY_PAGE, null);
+    }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/request/RegisterSettlementAccountRequest.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/request/RegisterSettlementAccountRequest.java
@@ -39,10 +39,6 @@ public class RegisterSettlementAccountRequest {
     private String accountHolderBirthDate;
 
     @NotNull
-    @Schema(description = "계좌 유형", allowableValues = {"WITHDRAWAL", "SETTLEMENT"}, example = "SETTLEMENT")
+    @Schema(description = "계좌 유형. 반드시 SETTLEMENT 이어야 합니다.", allowableValues = {"SETTLEMENT"}, example = "SETTLEMENT")
     private AccountType accountType;
-
-    @NotNull
-    @Schema(description = "대표 계좌 여부", example = "true")
-    private Boolean isPrimary;
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/enums/BankAuthFlow.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/enums/BankAuthFlow.java
@@ -1,0 +1,6 @@
+package pbl2.sub119.backend.bankaccounts.enums;
+
+public enum BankAuthFlow {
+    PARTY_CREATE,
+    MY_PAGE
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/mapper/BankMapper.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/mapper/BankMapper.java
@@ -26,6 +26,8 @@ public interface BankMapper {
 
     int clearPrimaryByUserId(@Param("userId") Long userId);
 
+    int deactivateSettlementAccountsByUserId(@Param("userId") Long userId);
+
     int updateSettlementAccountMeta(BankAccount bankAccount);
     int updateVerificationSuccess(@Param("userId") Long userId, @Param("fintechUseNum") String fintechUseNum);
     int updateVerificationFailure(@Param("userId") Long userId,

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthStateStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthStateStore.java
@@ -14,7 +14,13 @@ public class BankAuthStateStore {
 
     public String create(Long userId, String productId) {
         String state = UUID.randomUUID().toString().replace("-", "");
-        store.put(state, new BankAuthState(userId, productId));
+        store.put(state, BankAuthState.forPartyCreate(userId, productId));
+        return state;
+    }
+
+    public String createForMyPage(Long userId) {
+        String state = UUID.randomUUID().toString().replace("-", "");
+        store.put(state, BankAuthState.forMyPage(userId));
         return state;
     }
 

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
@@ -12,6 +12,7 @@ import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountReq
 import pbl2.sub119.backend.bankaccounts.dto.response.BankAccountSummaryResponse;
 import pbl2.sub119.backend.bankaccounts.dto.response.PrimaryBankAccountResponse;
 import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
+import pbl2.sub119.backend.bankaccounts.enums.AccountType;
 import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
 import pbl2.sub119.backend.bankaccounts.mapper.BankMapper;
 import pbl2.sub119.backend.common.exception.BusinessException;
@@ -22,6 +23,7 @@ import java.util.List;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_FAILED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_CONNECTED_ACCOUNT_NOT_FOUND;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_INVALID_ACCOUNT_TYPE;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_PRIMARY_ACCOUNT_NOT_FOUND;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED;
 
@@ -76,17 +78,19 @@ public class BankService {
 
     @Transactional
     public void registerSettlementAccount(Long userId, RegisterSettlementAccountRequest request) {
+        if (request.getAccountType() != AccountType.SETTLEMENT) {
+            throw new BusinessException(BANK_INVALID_ACCOUNT_TYPE);
+        }
+
         BankAccount connectedAccount = bankMapper.findByUserIdAndFintechUseNum(userId, request.getFintechUseNum());
         if (connectedAccount == null) {
             throw new BusinessException(BANK_CONNECTED_ACCOUNT_NOT_FOUND);
         }
 
-        LocalDateTime now = LocalDateTime.now();
-        boolean isPrimary = Boolean.TRUE.equals(request.getIsPrimary());
+        // 기존 활성 정산계좌 비활성화 (account_type/is_primary 초기화)
+        bankMapper.deactivateSettlementAccountsByUserId(userId);
 
-        if (isPrimary) {
-            bankMapper.clearPrimaryByUserId(userId);
-        }
+        LocalDateTime now = LocalDateTime.now();
 
         BankAccount bankAccount = BankAccount.builder()
                 .userId(userId)
@@ -95,8 +99,8 @@ public class BankService {
                 .accountNumber(request.getAccountNumber())
                 .accountHolderName(request.getAccountHolderName())
                 .accountHolderBirthDate(request.getAccountHolderBirthDate())
-                .accountType(request.getAccountType())
-                .isPrimary(isPrimary)
+                .accountType(AccountType.SETTLEMENT)
+                .isPrimary(true)
                 .verificationStatus(VerificationStatus.PENDING)
                 .verifiedAt(null)
                 .lastVerifiedAt(now)
@@ -173,6 +177,15 @@ public class BankService {
 //            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED);
 //        }
         bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
+    }
+
+    @Transactional
+    public void deactivateSettlementAccount(Long userId) {
+        BankAccount primary = bankMapper.findPrimaryByUserId(userId);
+        if (primary == null) {
+            throw new BusinessException(BANK_PRIMARY_ACCOUNT_NOT_FOUND);
+        }
+        bankMapper.deactivateSettlementAccountsByUserId(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/party/settings/service/PartySettingsQueryService.java
@@ -1,11 +1,9 @@
 package pbl2.sub119.backend.party.settings.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
-import pbl2.sub119.backend.bankaccounts.enums.AccountType;
 import pbl2.sub119.backend.bankaccounts.mapper.BankMapper;
 import pbl2.sub119.backend.common.enumerated.PartyMemberStatus;
 import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
@@ -170,10 +168,6 @@ public class PartySettingsQueryService {
     }
 
     private BankAccount findSettlementAccount(final Long hostUserId) {
-        final List<BankAccount> accounts = bankMapper.findAllByUserId(hostUserId);
-        return accounts.stream()
-                .filter(a -> a.getAccountType() == AccountType.SETTLEMENT)
-                .findFirst()
-                .orElse(null);
+        return bankMapper.findPrimaryByUserId(hostUserId);
     }
 }

--- a/src/main/java/pbl2/sub119/backend/user/service/UserService.java
+++ b/src/main/java/pbl2/sub119/backend/user/service/UserService.java
@@ -38,9 +38,9 @@ public class UserService {
             throw new IllegalArgumentException("이미 회원가입이 완료된 회원입니다.");
         }
 
-        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
-            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
-        }
+        //if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
+        //    throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
+        //}
 
         validateNicknameDuplication(user.getId(), request.nickname());
         validatePhoneNumberDuplication(user.getId(), request.phoneNumber());
@@ -59,7 +59,7 @@ public class UserService {
                 UserStatus.ACTIVE.name()
         );
 
-        phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
+        //phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
 
         final UserEntity updatedUser = findActiveUserOrThrow(user.getId());
         return UserSignUpResponse.from(updatedUser);

--- a/src/main/java/pbl2/sub119/backend/user/service/UserService.java
+++ b/src/main/java/pbl2/sub119/backend/user/service/UserService.java
@@ -38,9 +38,9 @@ public class UserService {
             throw new IllegalArgumentException("이미 회원가입이 완료된 회원입니다.");
         }
 
-        //if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
-        //    throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
-        //}
+        if (!phoneVerificationService.isVerified(accessor.getUserId(), request.phoneNumber())) {
+            throw new BusinessException(ErrorCode.PHONE_NOT_VERIFIED);
+        }
 
         validateNicknameDuplication(user.getId(), request.nickname());
         validatePhoneNumberDuplication(user.getId(), request.phoneNumber());
@@ -59,7 +59,7 @@ public class UserService {
                 UserStatus.ACTIVE.name()
         );
 
-        //phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
+        phoneVerificationService.consumeVerification(accessor.getUserId(), request.phoneNumber());
 
         final UserEntity updatedUser = findActiveUserOrThrow(user.getId());
         return UserSignUpResponse.from(updatedUser);

--- a/src/main/resources/mapper/bankAccounts/BankAccountMapper.xml
+++ b/src/main/resources/mapper/bankAccounts/BankAccountMapper.xml
@@ -79,6 +79,7 @@
             account_type, is_primary, verification_status, verified_at, last_verified_at, fail_reason, updated_at
         FROM bank_accounts
         WHERE user_id = #{userId}
+          AND account_type = 'SETTLEMENT'
           AND is_primary = TRUE
         ORDER BY id DESC
         LIMIT 1
@@ -129,6 +130,23 @@
             updated_at = NOW()
         WHERE user_id = #{userId}
           AND is_primary = TRUE
+    </update>
+
+    <update id="deactivateSettlementAccountsByUserId">
+        UPDATE bank_accounts
+        SET account_type              = NULL,
+            bank_code                 = NULL,
+            account_number            = NULL,
+            account_holder_name       = NULL,
+            account_holder_birth_date = NULL,
+            is_primary                = FALSE,
+            verification_status       = 'PENDING',
+            verified_at               = NULL,
+            last_verified_at          = NULL,
+            fail_reason               = NULL,
+            updated_at                = NOW()
+        WHERE user_id = #{userId}
+          AND account_type = 'SETTLEMENT'
     </update>
 
     <update id="updateSettlementAccountMeta"


### PR DESCRIPTION
## 변경 배경
- 파티 생성 시 계좌 인증과 마이페이지 계좌 재인증 시나리오를 분리할 필요가 있었음
- 정산계좌 등록/교체 동작과 프론트 refresh 시퀀스 간 정합성 이슈가 있었음
- invalid state 리다이렉트 UX와 정산계좌 비활성화 데이터 해석 이슈를 보완함

## 핵심 변경
1. 은행 인증 flow 분기 도입
- `BankAuthFlow` 추가: `PARTY_CREATE`, `MY_PAGE`
- `BankAuthState` 확장: `userId`, `flow`, `productId(optional)`
- `BankAuthStateStore` 확장:
  - 기존 `create(userId, productId)` 유지 (파티 생성)
  - 신규 `createForMyPage(userId)` 추가 (마이페이지)

2. 인증 URL API 분리
- 기존 유지: `GET /api/v1/bank/authorize-url?productId=...` (파티 생성용)
- 신규 추가: `GET /api/v1/bank/authorize-url/mypage` (마이페이지용)

3. callback 리다이렉트 분기
- `state.flow` 기준으로 프론트 복귀 경로 분기
  - `PARTY_CREATE` -> `/party/create/{productId}/host/account-register`
  - `MY_PAGE` -> `/mypage/account-register`
- invalid state 폴백을 특정 파티 경로 하드코딩에서 `frontendBaseUrl` 루트로 변경

4. 정산계좌 해제 API 추가
- 신규: `DELETE /api/v1/bank/settlement` (204 No Content)
- 동작: 활성 정산계좌(`account_type=SETTLEMENT`, `is_primary=true`) 비활성화

5. 정산계좌 등록/교체 정책 정리
- `registerAccount()`는 upsert 유지 (재인증 후 목록 refresh 가능)
- `registerSettlementAccount()`는 기존 활성 정산계좌 비활성화 후 선택 계좌 활성화
- row 물리삭제가 아니라 연결 계좌 목록은 유지

6. 비활성화 쿼리 보강
- `deactivateSettlementAccountsByUserId`가 정산 메타 전체 초기화
  - `account_type`, `bank_code`, `account_number`, `account_holder_name`, `account_holder_birth_date`,
    `is_primary`, `verified_at`, `last_verified_at`, `fail_reason` 정리
  - `verification_status`는 `NOT NULL` 제약 고려해 `'PENDING'`으로 처리

## API 변경 사항
- Added: `GET /api/v1/bank/authorize-url/mypage`
- Added: `DELETE /api/v1/bank/settlement`
- Maintained: `GET /api/v1/bank/authorize-url?productId=...`
- Maintained: `POST /api/v1/bank/settlement` (`isPrimary` 미사용 정책)

## 문서(Swagger) 반영
- 파티 생성용/마이페이지용 인증 URL 용도 분리 설명 추가
- callback flow별 복귀 경로 명시
- 정산계좌 해제 API 명세 추가
- 정산계좌 등록/교체 시퀀스 설명 보강

## 프론트 영향
- 파티 생성 플로우 기존 호출 유지
- 마이페이지는 `/authorize-url/mypage` 호출로 전환 필요
- 루트(`/`)에서 `bankAuthSuccess`, `message` 쿼리 처리 필요 (invalid state 폴백 대응)
- 정산계좌 해제 후 메타 값 null 가능성 고려해 목록 렌더링 null-safe 처리 필요

## 검증
- `./gradlew compileJava -x test` 성공
- 수동 확인 기준:
  - 파티 생성 인증 URL/callback 정상
  - 마이페이지 인증 URL/callback 정상
  - 정산계좌 등록/교체/해제 시 활성 정산계좌 단일성 유지
  - `GET /bank/accounts` 목록 유지, `GET /bank/accounts/primary` 동작 일관성 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 계좌 비활성화 기능 추가
  * 마이페이지용 계좌 재인증 API 추가

* **버그 수정**
  * 결제 계좌 등록 시 계좌 유형 검증 강화
  * 결제 계좌 조회 로직 개선

* **문서**
  * OpenAPI/Swagger 문서 업데이트 (인증 흐름 및 엔드포인트 설명 추가)

* **개선**
  * 회원가입 시 휴대폰 인증 검증 로직 조정
  * 인증 상태 관리 구조 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/116)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->