### PR TITLE
fix: SWITCH_WAITING 파티원 이용 상태를 SCHEDULED로 분리하여 이용 중 오표시 수정

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/history/controller/docs/PartyHistoryDocs.java
+++ b/src/main/java/pbl2/sub119/backend/party/history/controller/docs/PartyHistoryDocs.java
@@ -47,8 +47,9 @@ public interface PartyHistoryDocs {
                     - MEMBER : 파티원
 
                     상태값(status) 안내:
-                    - USING : 이용 중
-                    - ENDED : 종료
+                    - USING      : 이용 중 (ACTIVE, LEAVE_RESERVED)
+                    - SCHEDULED  : 이용 예정 (결원 참여 후 다음 사이클 시작 대기 중, SWITCH_WAITING)
+                    - ENDED      : 종료 (LEFT, REMOVED, 파티 해체)
 
                     기간 기준:
                     - startAt : party_member.service_start_at

--- a/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
+++ b/src/main/resources/mapper/party/PartyHistoryQueryMapper.xml
@@ -17,6 +17,7 @@
             CASE
                 WHEN pm.status IN ('LEFT', 'REMOVED') THEN 'ENDED'
                 WHEN p.operation_status = 'TERMINATED' THEN 'ENDED'
+                WHEN pm.status = 'SWITCH_WAITING' THEN 'SCHEDULED'
                 ELSE 'USING'
                 END AS status,
             pm.service_start_at AS startAt,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 설명서
* 파티 히스토리 상태 값(USING, SCHEDULED, ENDED) 설명 추가

## 버그 수정
* 파티 상태 표시 개선으로 더 정확한 상태 정보 제공

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->