### PR TITLE
{BankAccount] KFTC 응답 경로 정합화 및 레거시 계좌 노출 차단

### DIFF
--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
@@ -77,6 +77,12 @@ public interface BankDocs {
                     - 기존 활성 정산계좌(account_type=SETTLEMENT, is_primary=true)가 비활성화되고, \
                     선택한 계좌 1건만 활성 정산계좌로 확정됩니다. 나머지 연결 계좌 row는 유지됩니다.
                     - 전체 처리는 단일 트랜잭션 내에서 원자적으로 수행됩니다.
+
+                    [캐시 miss 복구 경로] (등록 보장 전용)
+                    - Redis 후보 캐시(10분) 만료 시: 인증 토큰 캐시(45분)로 KFTC 재조회 후 자동 복구.
+                    - KFTC 재조회에서 해당 계좌를 찾으면 등록 진행.
+                    - 인증 토큰 만료 또는 KFTC에 해당 계좌 없음: 401(BANK008) 반환. 재인증 필요.
+                    - 등록 성공 시 해당 계좌가 GET /bank/accounts 조회 가능 목록에 자동 반영됩니다.
                     """
     )
     @ApiResponses(value = {
@@ -84,11 +90,9 @@ public interface BankDocs {
                     content = @Content(schema = @Schema(implementation = String.class))),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 또는 계좌 검증 실패 (BANK002, BANK004)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
+            @ApiResponse(responseCode = "401", description = "인증 실패 또는 KFTC 인증 만료 — 재인증 필요 (BANK008)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "연결 계좌 없음 (BANK001)",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "등록/검증 요청 실패 (BANK003, BANK005)",
+            @ApiResponse(responseCode = "500", description = "등록/KFTC 연결 요청 실패 (BANK003, BANK005, BANK007)",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     String registerSettlementAccount(
@@ -119,10 +123,11 @@ public interface BankDocs {
     @Operation(
             summary = "연결 계좌 목록 조회",
             description = """
-                    금융결제원 최신 인증 후보(Redis, TTL 10분) 기준으로 계좌 목록을 반환합니다.
-                    - 재인증 후 TTL 이내: 최신 인증 스냅샷(Redis 후보)만 노출되며 과거 인증 계좌는 누적되지 않습니다.
-                    - Redis TTL 만료 또는 캐시 미스: 기존 DB 목록으로 fallback합니다.
-                    - 정산계좌 활성 상태(account_type=SETTLEMENT, is_primary=true)는 POST /bank/settlement 호출 시점에만 확정됩니다.
+                    활성 정산계좌 + POST /bank/settlement 등록 완료 계좌만 노출합니다. (표시 전용 — 엄격)
+                    - 활성 정산계좌(account_type=SETTLEMENT, is_primary=true)는 항상 포함됩니다.
+                    - 이번 인증 후보 중 POST /bank/settlement 에 성공한 계좌만 추가로 포함됩니다.
+                    - KFTC 인증 후보 전체는 노출하지 않습니다. 레거시·미등록 후보는 항상 제외됩니다.
+                    - 재인증 직후라도 POST /bank/settlement 미수행 계좌는 목록에 표시되지 않습니다.
                     """
     )
     @ApiResponses(value = {

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/controller/docs/BankDocs.java
@@ -118,7 +118,12 @@ public interface BankDocs {
 
     @Operation(
             summary = "연결 계좌 목록 조회",
-            description = "인증 사용자의 연결된 계좌 목록을 조회합니다."
+            description = """
+                    금융결제원 최신 인증 후보(Redis, TTL 10분) 기준으로 계좌 목록을 반환합니다.
+                    - 재인증 후 TTL 이내: 최신 인증 스냅샷(Redis 후보)만 노출되며 과거 인증 계좌는 누적되지 않습니다.
+                    - Redis TTL 만료 또는 캐시 미스: 기존 DB 목록으로 fallback합니다.
+                    - 정산계좌 활성 상태(account_type=SETTLEMENT, is_primary=true)는 POST /bank/settlement 호출 시점에만 확정됩니다.
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공",

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthTokenDto.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthTokenDto.java
@@ -1,0 +1,16 @@
+package pbl2.sub119.backend.bankaccounts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BankAuthTokenDto {
+    private String accessToken;
+    private String refreshToken;
+    private String userSeqNo;
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthTokenDto.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankAuthTokenDto.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString(exclude = {"accessToken", "refreshToken"})
 public class BankAuthTokenDto {
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankCandidateDto.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankCandidateDto.java
@@ -4,11 +4,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString(exclude = {"accessToken", "refreshToken"})
 public class BankCandidateDto {
     private String fintechUseNum;
     private String bankTranId;

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankCandidateDto.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/BankCandidateDto.java
@@ -1,0 +1,20 @@
+package pbl2.sub119.backend.bankaccounts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BankCandidateDto {
+    private String fintechUseNum;
+    private String bankTranId;
+    private String bankName;
+    private String accountAlias;
+    private String accountNumMasked;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/BankAccountSummaryResponse.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/dto/response/BankAccountSummaryResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import pbl2.sub119.backend.bankaccounts.dto.BankCandidateDto;
 import pbl2.sub119.backend.bankaccounts.entity.BankAccount;
 import pbl2.sub119.backend.bankaccounts.enums.AccountType;
 import pbl2.sub119.backend.bankaccounts.enums.VerificationStatus;
@@ -48,6 +49,19 @@ public class BankAccountSummaryResponse {
                 bankAccount.getAccountType(),
                 bankAccount.getIsPrimary(),
                 bankAccount.getVerificationStatus()
+        );
+    }
+
+    public static BankAccountSummaryResponse fromCandidate(BankCandidateDto candidate) {
+        return new BankAccountSummaryResponse(
+                null,
+                candidate.getFintechUseNum(),
+                candidate.getBankName(),
+                candidate.getAccountAlias(),
+                candidate.getAccountNumMasked(),
+                null,
+                null,
+                null
         );
     }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthTokenStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthTokenStore.java
@@ -22,7 +22,7 @@ public class BankAuthTokenStore {
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
 
-    public void save(Long userId, String accessToken, String refreshToken, String userSeqNo) {
+    public boolean save(Long userId, String accessToken, String refreshToken, String userSeqNo) {
         try {
             BankAuthTokenDto dto = BankAuthTokenDto.builder()
                     .accessToken(accessToken)
@@ -30,8 +30,10 @@ public class BankAuthTokenStore {
                     .userSeqNo(userSeqNo)
                     .build();
             redisTemplate.opsForValue().set(KEY_PREFIX + userId, objectMapper.writeValueAsString(dto), TTL);
+            return true;
         } catch (Exception e) {
             log.warn("Failed to save bank auth token to Redis. userId={}", userId, e);
+            return false;
         }
     }
 

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthTokenStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankAuthTokenStore.java
@@ -1,0 +1,56 @@
+package pbl2.sub119.backend.bankaccounts.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import pbl2.sub119.backend.bankaccounts.dto.BankAuthTokenDto;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankAuthTokenStore {
+
+    private static final String KEY_PREFIX = "bank:auth:";
+    // 후보 캐시(10분)보다 긴 TTL로 miss 복구 경로를 보장한다
+    private static final Duration TTL = Duration.ofMinutes(45);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void save(Long userId, String accessToken, String refreshToken, String userSeqNo) {
+        try {
+            BankAuthTokenDto dto = BankAuthTokenDto.builder()
+                    .accessToken(accessToken)
+                    .refreshToken(refreshToken)
+                    .userSeqNo(userSeqNo)
+                    .build();
+            redisTemplate.opsForValue().set(KEY_PREFIX + userId, objectMapper.writeValueAsString(dto), TTL);
+        } catch (Exception e) {
+            log.warn("Failed to save bank auth token to Redis. userId={}", userId, e);
+        }
+    }
+
+    public Optional<BankAuthTokenDto> find(Long userId) {
+        try {
+            String json = redisTemplate.opsForValue().get(KEY_PREFIX + userId);
+            if (json == null) return Optional.empty();
+            return Optional.of(objectMapper.readValue(json, BankAuthTokenDto.class));
+        } catch (Exception e) {
+            log.warn("Failed to read bank auth token from Redis. userId={}", userId, e);
+            return Optional.empty();
+        }
+    }
+
+    public void remove(Long userId) {
+        try {
+            redisTemplate.delete(KEY_PREFIX + userId);
+        } catch (Exception e) {
+            log.warn("Failed to remove bank auth token from Redis. userId={}", userId, e);
+        }
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankCandidateStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankCandidateStore.java
@@ -1,0 +1,65 @@
+package pbl2.sub119.backend.bankaccounts.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import pbl2.sub119.backend.bankaccounts.dto.BankCandidateDto;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankCandidateStore {
+
+    private static final String KEY_PREFIX = "bank:candidates:";
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void save(Long userId, List<BankCandidateDto> candidates) {
+        try {
+            String json = objectMapper.writeValueAsString(candidates);
+            redisTemplate.opsForValue().set(KEY_PREFIX + userId, json, TTL);
+        } catch (Exception e) {
+            log.warn("Failed to save bank candidates to Redis. userId={}", userId, e);
+        }
+    }
+
+    public List<BankCandidateDto> findAll(Long userId) {
+        try {
+            String json = redisTemplate.opsForValue().get(KEY_PREFIX + userId);
+            if (json == null) {
+                return null;
+            }
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Failed to read bank candidates from Redis. userId={}", userId, e);
+            return null;
+        }
+    }
+
+    public Optional<BankCandidateDto> findByFintechUseNum(Long userId, String fintechUseNum) {
+        List<BankCandidateDto> all = findAll(userId);
+        if (all == null) {
+            return Optional.empty();
+        }
+        return all.stream()
+                .filter(c -> fintechUseNum.equals(c.getFintechUseNum()))
+                .findFirst();
+    }
+
+    public void remove(Long userId) {
+        try {
+            redisTemplate.delete(KEY_PREFIX + userId);
+        } catch (Exception e) {
+            log.warn("Failed to remove bank candidates from Redis. userId={}", userId, e);
+        }
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankSelectedStore.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankSelectedStore.java
@@ -1,0 +1,49 @@
+package pbl2.sub119.backend.bankaccounts.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BankSelectedStore {
+
+    private static final String KEY_PREFIX = "bank:selected:";
+    // 후보 TTL(10분)보다 충분히 길게 유지 — 정산 등록 이력 보존
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void add(Long userId, String fintechUseNum) {
+        String key = KEY_PREFIX + userId;
+        try {
+            redisTemplate.opsForSet().add(key, fintechUseNum);
+            redisTemplate.expire(key, TTL);
+        } catch (Exception e) {
+            log.warn("Failed to add to bank selected store. userId={}, fintechUseNum={}", userId, fintechUseNum, e);
+        }
+    }
+
+    public Set<String> findAll(Long userId) {
+        try {
+            Set<String> members = redisTemplate.opsForSet().members(KEY_PREFIX + userId);
+            return members != null ? members : Set.of();
+        } catch (Exception e) {
+            log.warn("Failed to read bank selected store. userId={}", userId, e);
+            return Set.of();
+        }
+    }
+
+    public void remove(Long userId) {
+        try {
+            redisTemplate.delete(KEY_PREFIX + userId);
+        } catch (Exception e) {
+            log.warn("Failed to remove bank selected store. userId={}", userId, e);
+        }
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.bankaccounts.client.KftcApiClient;
+import pbl2.sub119.backend.bankaccounts.dto.BankCandidateDto;
 import pbl2.sub119.backend.bankaccounts.dto.KftcAccountRealNameResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcTokenResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcUserInfoResponse;
@@ -19,6 +20,7 @@ import pbl2.sub119.backend.common.exception.BusinessException;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_FAILED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
@@ -34,8 +36,8 @@ public class BankService {
 
     private final BankMapper bankMapper;
     private final KftcApiClient kftcApiClient;
+    private final BankCandidateStore bankCandidateStore;
 
-    @Transactional
     public void registerAccount(Long userId, String code) {
         log.info("KFTC account registration started. userId={}", userId);
 
@@ -44,36 +46,24 @@ public class BankService {
 
         if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
             log.warn("KFTC account list is empty. userId={}", userId);
+            bankCandidateStore.save(userId, List.of());
             return;
         }
 
-        int processedCount = 0;
+        List<BankCandidateDto> candidates = userInfo.getResList().stream()
+                .map(dto -> BankCandidateDto.builder()
+                        .fintechUseNum(dto.getFintechUseNum())
+                        .bankTranId(dto.getBankTranId())
+                        .bankName(dto.getBankName())
+                        .accountAlias(dto.getAccountAlias())
+                        .accountNumMasked(dto.getAccountNumMasked())
+                        .accessToken(tokenResponse.getAccessToken())
+                        .refreshToken(tokenResponse.getRefreshToken())
+                        .build())
+                .toList();
 
-        for (KftcUserInfoResponse.KftcAccountDto accountDto : userInfo.getResList()) {
-            BankAccount bankAccount = BankAccount.builder()
-                    .userId(userId)
-                    .bankTranId(accountDto.getBankTranId())
-                    .fintechUseNum(accountDto.getFintechUseNum())
-                    .accessToken(tokenResponse.getAccessToken())
-                    .refreshToken(tokenResponse.getRefreshToken())
-                    .bankName(accountDto.getBankName())
-                    .accountAlias(accountDto.getAccountAlias())
-                    .accountNumMasked(accountDto.getAccountNumMasked())
-                    .balanceAmt(0L)
-                    .build();
-
-            boolean exists = bankMapper.existsByUserIdAndFintechUseNum(userId, accountDto.getFintechUseNum());
-
-            if (exists) {
-                bankMapper.updateBankAccount(bankAccount);
-            } else {
-                bankMapper.saveBankAccount(bankAccount);
-            }
-
-            processedCount++;
-        }
-
-        log.info("KFTC account registration completed. userId={}, accountCount={}", userId, processedCount);
+        bankCandidateStore.save(userId, candidates);
+        log.info("KFTC account candidates cached. userId={}, accountCount={}", userId, candidates.size());
     }
 
     @Transactional
@@ -82,9 +72,17 @@ public class BankService {
             throw new BusinessException(BANK_INVALID_ACCOUNT_TYPE);
         }
 
-        BankAccount connectedAccount = bankMapper.findByUserIdAndFintechUseNum(userId, request.getFintechUseNum());
-        if (connectedAccount == null) {
-            throw new BusinessException(BANK_CONNECTED_ACCOUNT_NOT_FOUND);
+        Optional<BankCandidateDto> candidateOpt = bankCandidateStore.findByFintechUseNum(userId, request.getFintechUseNum());
+
+        if (candidateOpt.isPresent()) {
+            // 최신 인증 경로: Redis 후보에서 KFTC 메타 확보 후 DB row 보장
+            ensureKftcRowExists(userId, candidateOpt.get());
+        } else {
+            // Redis 미스(TTL 만료 등): DB fallback
+            BankAccount connectedAccount = bankMapper.findByUserIdAndFintechUseNum(userId, request.getFintechUseNum());
+            if (connectedAccount == null) {
+                throw new BusinessException(BANK_CONNECTED_ACCOUNT_NOT_FOUND);
+            }
         }
 
         // 기존 활성 정산계좌 비활성화 (account_type/is_primary 초기화)
@@ -112,6 +110,7 @@ public class BankService {
         if (updated != 1) {
             throw new BusinessException(BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED);
         }
+
         //실명검증 테스트베드
 //        try {
 //            KftcAccountRealNameResponse realNameResponse = kftcApiClient.requestAccountRealName(
@@ -140,6 +139,7 @@ public class BankService {
 //            if (verified) {
 //                bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
 //                log.info("Settlement account verified. userId={}, fintechUseNum={}", userId, request.getFintechUseNum());
+//                bankCandidateStore.remove(userId);
 //                return;
 //            }
 //
@@ -177,6 +177,7 @@ public class BankService {
 //            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED);
 //        }
         bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
+        bankCandidateStore.remove(userId);
     }
 
     @Transactional
@@ -190,6 +191,13 @@ public class BankService {
 
     @Transactional(readOnly = true)
     public List<BankAccountSummaryResponse> getAccounts(Long userId) {
+        List<BankCandidateDto> candidates = bankCandidateStore.findAll(userId);
+        if (candidates != null) {
+            return candidates.stream()
+                    .map(BankAccountSummaryResponse::fromCandidate)
+                    .toList();
+        }
+        log.warn("Bank candidate cache miss — falling back to DB. userId={}. Shown accounts may not reflect latest KFTC auth.", userId);
         return bankMapper.findAllByUserId(userId).stream()
                 .map(BankAccountSummaryResponse::from)
                 .toList();
@@ -202,6 +210,25 @@ public class BankService {
             throw new BusinessException(BANK_PRIMARY_ACCOUNT_NOT_FOUND);
         }
         return PrimaryBankAccountResponse.from(primary);
+    }
+
+    private void ensureKftcRowExists(Long userId, BankCandidateDto candidate) {
+        BankAccount kftcRow = BankAccount.builder()
+                .userId(userId)
+                .fintechUseNum(candidate.getFintechUseNum())
+                .bankTranId(candidate.getBankTranId())
+                .accessToken(candidate.getAccessToken())
+                .refreshToken(candidate.getRefreshToken())
+                .bankName(candidate.getBankName())
+                .accountAlias(candidate.getAccountAlias())
+                .accountNumMasked(candidate.getAccountNumMasked())
+                .balanceAmt(0L)
+                .build();
+        if (bankMapper.existsByUserIdAndFintechUseNum(userId, candidate.getFintechUseNum())) {
+            bankMapper.updateBankAccount(kftcRow);
+        } else {
+            bankMapper.saveBankAccount(kftcRow);
+        }
     }
 
     private String normalizeName(String name) {

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_CONNECT_REQUEST_FAILED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_AUTH_EXPIRED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_INVALID_ACCOUNT_TYPE;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_PRIMARY_ACCOUNT_NOT_FOUND;
@@ -42,32 +43,29 @@ public class BankService {
     private final BankAuthTokenStore bankAuthTokenStore;
     private final BankSelectedStore bankSelectedStore;
 
-    /**
-     * KFTC 콜백 처리: Redis 후보 캐시(10분) + 인증 토큰 캐시(45분)만 저장한다.
-     * DB upsert 없음 — callback 시 전체 계좌 인젝션 방지.
-     * 인증 토큰은 후보 TTL 만료 후 복구 경로로 사용된다.
-     */
     public void registerAccount(Long userId, String code) {
         log.info("KFTC account registration started. userId={}", userId);
 
         KftcTokenResponse tokenResponse = kftcApiClient.requestToken(code);
         KftcUserInfoResponse userInfo = kftcApiClient.requestUserInfo(tokenResponse);
 
-        // 새 인증 스냅샷 저장 전 기존 캐시를 제거해 덮어쓰기를 보장한다
+        // Ensure each callback starts from a clean snapshot.
         bankCandidateStore.remove(userId);
         bankAuthTokenStore.remove(userId);
         bankSelectedStore.remove(userId);
 
-        // 후보 TTL(10분) 만료 후에도 settlement 복구를 위해 별도 저장(45분)
-        bankAuthTokenStore.save(userId,
+        boolean tokenSaved = bankAuthTokenStore.save(
+                userId,
                 tokenResponse.getAccessToken(),
                 tokenResponse.getRefreshToken(),
-                tokenResponse.getUserSeqNo());
+                tokenResponse.getUserSeqNo()
+        );
+        if (!tokenSaved) {
+            throw new BusinessException(BANK_ACCOUNT_CONNECT_REQUEST_FAILED);
+        }
 
         if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
             log.warn("KFTC account list is empty. userId={}", userId);
-            bankCandidateStore.save(userId, List.of());
-            // null(miss)과 구분하기 위해 명시적 빈 스냅샷 저장
             bankCandidateStore.save(userId, List.of());
             return;
         }
@@ -84,7 +82,6 @@ public class BankService {
                         .build())
                 .toList();
 
-        //filter
         candidates = sanitizeCandidates(candidates);
         bankCandidateStore.save(userId, candidates);
         if (!candidates.isEmpty()) {
@@ -99,40 +96,32 @@ public class BankService {
             throw new BusinessException(BANK_INVALID_ACCOUNT_TYPE);
         }
 
-        Optional<BankCandidateDto> candidateOpt = bankCandidateStore.findByFintechUseNum(userId, request.getFintechUseNum());
+        Optional<BankCandidateDto> candidateOpt =
+                bankCandidateStore.findByFintechUseNum(userId, request.getFintechUseNum());
 
         if (candidateOpt.isPresent()) {
-            // 경로 A: Redis 후보 보유 → 해당 1건만 DB row 보장
             ensureKftcRowExists(userId, candidateOpt.get());
         } else {
-            // 경로 B/C: Redis 후보 miss
-            // recoverCandidates: auth token 없으면 null, KFTC 장애면 BusinessException 전파
             List<BankCandidateDto> recovered = recoverCandidates(userId);
-
-            if (recovered != null) {
-                // 경로 B: auth token 보유 + KFTC 재조회 성공
-                Optional<BankCandidateDto> recoveredOpt = recovered.stream()
-                        .filter(c -> request.getFintechUseNum().equals(c.getFintechUseNum()))
-                        .findFirst();
-                if (recoveredOpt.isPresent()) {
-                    ensureKftcRowExists(userId, recoveredOpt.get());
-                    bankCandidateStore.save(userId, recovered); // 재캐시
-                    ensureKftcRowExists(userId, recoveredOpt.get());
-                } else {
-                    // KFTC에 해당 계좌 없음: 링크 해제 상태
-                    throw new BusinessException(BANK_AUTH_EXPIRED);
-                }
-            } else {
-                // 경로 C: auth token도 만료 → 재인증 요구
-                // getAccounts가 miss 시 빈 목록을 반환하는 정책과 일관성 유지
+            if (recovered == null) {
                 throw new BusinessException(BANK_AUTH_EXPIRED);
             }
+
+            Optional<BankCandidateDto> recoveredOpt = recovered.stream()
+                    .filter(c -> request.getFintechUseNum().equals(c.getFintechUseNum()))
+                    .findFirst();
+
+            if (recoveredOpt.isEmpty()) {
+                throw new BusinessException(BANK_AUTH_EXPIRED);
+            }
+
+            ensureKftcRowExists(userId, recoveredOpt.get());
+            bankCandidateStore.save(userId, recovered);
         }
 
         bankMapper.deactivateSettlementAccountsByUserId(userId);
 
         LocalDateTime now = LocalDateTime.now();
-
         BankAccount bankAccount = BankAccount.builder()
                 .userId(userId)
                 .fintechUseNum(request.getFintechUseNum())
@@ -169,29 +158,23 @@ public class BankService {
         bankMapper.deactivateSettlementAccountsByUserId(userId);
     }
 
-    /**
-     * 계좌 목록 조회 (표시 전용 — 엄격):
-     * - 활성 정산계좌(primary) 항상 포함
-     * - 이번 인증 후보 중 POST /settlement 완료된 것만 포함 (화이트리스트 필터)
-     * - 후보 전체 노출 없음 / DB fallback 없음 (레거시 미노출 보장)
-     */
     public List<BankAccountSummaryResponse> getAccounts(Long userId) {
         BankAccount primary = bankMapper.findPrimaryByUserId(userId);
         List<BankCandidateDto> candidates = bankCandidateStore.findAll(userId);
         Set<String> selected = bankSelectedStore.findAll(userId);
 
-        // fintechUseNum 기준 중복 제거, primary 우선
         Map<String, BankAccountSummaryResponse> result = new LinkedHashMap<>();
-
         if (primary != null) {
             result.put(primary.getFintechUseNum(), BankAccountSummaryResponse.from(primary));
         }
 
         if (candidates != null) {
-            // 후보 전체 노출 금지: selected 화이트리스트만 통과
-            for (BankCandidateDto c : candidates) {
-                if (selected.contains(c.getFintechUseNum())) {
-                    result.putIfAbsent(c.getFintechUseNum(), BankAccountSummaryResponse.fromCandidate(c));
+            for (BankCandidateDto candidate : candidates) {
+                if (selected.contains(candidate.getFintechUseNum())) {
+                    result.putIfAbsent(
+                            candidate.getFintechUseNum(),
+                            BankAccountSummaryResponse.fromCandidate(candidate)
+                    );
                 }
             }
         }
@@ -208,29 +191,23 @@ public class BankService {
         return PrimaryBankAccountResponse.from(primary);
     }
 
-    // ── private helpers ──────────────────────────────────────────────────────
-
-    /**
-     * auth token Redis 캐시로 KFTC userInfo를 재조회해 후보 목록을 재구성한다.
-     * <p>
-     * null 반환: auth token 미보유(Redis miss) — caller가 DB fallback 처리.
-     * List 반환: KFTC 재조회 성공 (빈 리스트 포함).
-     * 예외 전파: KFTC API 장애 시 {@code BANK_ACCOUNT_CONNECT_REQUEST_FAILED} —
-     *            settlement은 전파, getAccounts는 흡수 후 DB fallback.
-     */
     private List<BankCandidateDto> recoverCandidates(Long userId) {
         Optional<BankAuthTokenDto> tokenOpt = bankAuthTokenStore.find(userId);
         if (tokenOpt.isEmpty()) {
             return null;
         }
-        // auth token 보유 → KFTC 재조회. BusinessException(BANK007)은 그대로 전파.
+
         BankAuthTokenDto stored = tokenOpt.get();
         KftcTokenResponse syntheticToken = new KftcTokenResponse(
-                stored.getAccessToken(), stored.getRefreshToken(), stored.getUserSeqNo(),
-                null, null, null);
+                stored.getAccessToken(),
+                stored.getRefreshToken(),
+                stored.getUserSeqNo(),
+                null,
+                null,
+                null
+        );
 
         KftcUserInfoResponse userInfo = kftcApiClient.requestUserInfo(syntheticToken);
-
         if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
             return List.of();
         }
@@ -248,13 +225,8 @@ public class BankService {
                 .toList();
 
         return sanitizeCandidates(recovered);
-
     }
 
-    /**
-     * fintechUseNum 기준으로 DB row가 있으면 KFTC 메타만 갱신, 없으면 신규 삽입.
-     * settlement 메타(account_type, is_primary, verification_*)는 updateBankAccount SQL이 건드리지 않는다.
-     */
     private void ensureKftcRowExists(Long userId, BankCandidateDto candidate) {
         BankAccount kftcRow = BankAccount.builder()
                 .userId(userId)
@@ -267,6 +239,7 @@ public class BankService {
                 .accountNumMasked(candidate.getAccountNumMasked())
                 .balanceAmt(0L)
                 .build();
+
         if (bankMapper.existsByUserIdAndFintechUseNum(userId, candidate.getFintechUseNum())) {
             bankMapper.updateBankAccount(kftcRow);
         } else {
@@ -289,30 +262,28 @@ public class BankService {
     }
 
     private List<BankCandidateDto> sanitizeCandidates(List<BankCandidateDto> raw) {
-        if (raw == null || raw.isEmpty()) return List.of();
+        if (raw == null || raw.isEmpty()) {
+            return List.of();
+        }
 
-        // 순서 유지 + 중복 제거
         Map<String, BankCandidateDto> dedup = new LinkedHashMap<>();
-
-        for (BankCandidateDto c : raw) {
-            if (c.getFintechUseNum() == null || c.getFintechUseNum().isBlank()) continue;
-
-            // 같은 은행 + 같은 마스킹 계좌는 1건만 노출
-            String key = nz(c.getBankName()) + "|" + nz(c.getAccountNumMasked());
-            if (key.equals("|")) {
-                key = c.getFintechUseNum();
+        for (BankCandidateDto candidate : raw) {
+            if (candidate.getFintechUseNum() == null || candidate.getFintechUseNum().isBlank()) {
+                continue;
             }
 
-            // 키가 비정상이면 fintech 번호로 대체
-            if (key.equals("|")) key = c.getFintechUseNum();
+            String key = nz(candidate.getBankName()) + "|" + nz(candidate.getAccountNumMasked());
+            if (key.equals("|")) {
+                key = candidate.getFintechUseNum();
+            }
 
-            dedup.putIfAbsent(key, c);
+            dedup.putIfAbsent(key, candidate);
         }
 
         return new ArrayList<>(dedup.values());
     }
 
-    private String nz(String v) {
-        return v == null ? "" : v.trim();
+    private String nz(String value) {
+        return value == null ? "" : value.trim();
     }
 }

--- a/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
+++ b/src/main/java/pbl2/sub119/backend/bankaccounts/service/BankService.java
@@ -5,8 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.bankaccounts.client.KftcApiClient;
+import pbl2.sub119.backend.bankaccounts.dto.BankAuthTokenDto;
 import pbl2.sub119.backend.bankaccounts.dto.BankCandidateDto;
-import pbl2.sub119.backend.bankaccounts.dto.KftcAccountRealNameResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcTokenResponse;
 import pbl2.sub119.backend.bankaccounts.dto.KftcUserInfoResponse;
 import pbl2.sub119.backend.bankaccounts.dto.request.RegisterSettlementAccountRequest;
@@ -19,12 +19,14 @@ import pbl2.sub119.backend.bankaccounts.mapper.BankMapper;
 import pbl2.sub119.backend.common.exception.BusinessException;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
-import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_FAILED;
-import static pbl2.sub119.backend.common.error.ErrorCode.BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED;
-import static pbl2.sub119.backend.common.error.ErrorCode.BANK_CONNECTED_ACCOUNT_NOT_FOUND;
+import static pbl2.sub119.backend.common.error.ErrorCode.BANK_AUTH_EXPIRED;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_INVALID_ACCOUNT_TYPE;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_PRIMARY_ACCOUNT_NOT_FOUND;
 import static pbl2.sub119.backend.common.error.ErrorCode.BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED;
@@ -37,15 +39,35 @@ public class BankService {
     private final BankMapper bankMapper;
     private final KftcApiClient kftcApiClient;
     private final BankCandidateStore bankCandidateStore;
+    private final BankAuthTokenStore bankAuthTokenStore;
+    private final BankSelectedStore bankSelectedStore;
 
+    /**
+     * KFTC 콜백 처리: Redis 후보 캐시(10분) + 인증 토큰 캐시(45분)만 저장한다.
+     * DB upsert 없음 — callback 시 전체 계좌 인젝션 방지.
+     * 인증 토큰은 후보 TTL 만료 후 복구 경로로 사용된다.
+     */
     public void registerAccount(Long userId, String code) {
         log.info("KFTC account registration started. userId={}", userId);
 
         KftcTokenResponse tokenResponse = kftcApiClient.requestToken(code);
         KftcUserInfoResponse userInfo = kftcApiClient.requestUserInfo(tokenResponse);
 
+        // 새 인증 스냅샷 저장 전 기존 캐시를 제거해 덮어쓰기를 보장한다
+        bankCandidateStore.remove(userId);
+        bankAuthTokenStore.remove(userId);
+        bankSelectedStore.remove(userId);
+
+        // 후보 TTL(10분) 만료 후에도 settlement 복구를 위해 별도 저장(45분)
+        bankAuthTokenStore.save(userId,
+                tokenResponse.getAccessToken(),
+                tokenResponse.getRefreshToken(),
+                tokenResponse.getUserSeqNo());
+
         if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
             log.warn("KFTC account list is empty. userId={}", userId);
+            bankCandidateStore.save(userId, List.of());
+            // null(miss)과 구분하기 위해 명시적 빈 스냅샷 저장
             bankCandidateStore.save(userId, List.of());
             return;
         }
@@ -62,7 +84,12 @@ public class BankService {
                         .build())
                 .toList();
 
+        //filter
+        candidates = sanitizeCandidates(candidates);
         bankCandidateStore.save(userId, candidates);
+        if (!candidates.isEmpty()) {
+            bankSelectedStore.add(userId, candidates.get(0).getFintechUseNum());
+        }
         log.info("KFTC account candidates cached. userId={}, accountCount={}", userId, candidates.size());
     }
 
@@ -75,17 +102,33 @@ public class BankService {
         Optional<BankCandidateDto> candidateOpt = bankCandidateStore.findByFintechUseNum(userId, request.getFintechUseNum());
 
         if (candidateOpt.isPresent()) {
-            // 최신 인증 경로: Redis 후보에서 KFTC 메타 확보 후 DB row 보장
+            // 경로 A: Redis 후보 보유 → 해당 1건만 DB row 보장
             ensureKftcRowExists(userId, candidateOpt.get());
         } else {
-            // Redis 미스(TTL 만료 등): DB fallback
-            BankAccount connectedAccount = bankMapper.findByUserIdAndFintechUseNum(userId, request.getFintechUseNum());
-            if (connectedAccount == null) {
-                throw new BusinessException(BANK_CONNECTED_ACCOUNT_NOT_FOUND);
+            // 경로 B/C: Redis 후보 miss
+            // recoverCandidates: auth token 없으면 null, KFTC 장애면 BusinessException 전파
+            List<BankCandidateDto> recovered = recoverCandidates(userId);
+
+            if (recovered != null) {
+                // 경로 B: auth token 보유 + KFTC 재조회 성공
+                Optional<BankCandidateDto> recoveredOpt = recovered.stream()
+                        .filter(c -> request.getFintechUseNum().equals(c.getFintechUseNum()))
+                        .findFirst();
+                if (recoveredOpt.isPresent()) {
+                    ensureKftcRowExists(userId, recoveredOpt.get());
+                    bankCandidateStore.save(userId, recovered); // 재캐시
+                    ensureKftcRowExists(userId, recoveredOpt.get());
+                } else {
+                    // KFTC에 해당 계좌 없음: 링크 해제 상태
+                    throw new BusinessException(BANK_AUTH_EXPIRED);
+                }
+            } else {
+                // 경로 C: auth token도 만료 → 재인증 요구
+                // getAccounts가 miss 시 빈 목록을 반환하는 정책과 일관성 유지
+                throw new BusinessException(BANK_AUTH_EXPIRED);
             }
         }
 
-        // 기존 활성 정산계좌 비활성화 (account_type/is_primary 초기화)
         bankMapper.deactivateSettlementAccountsByUserId(userId);
 
         LocalDateTime now = LocalDateTime.now();
@@ -111,73 +154,10 @@ public class BankService {
             throw new BusinessException(BANK_SETTLEMENT_ACCOUNT_REGISTER_FAILED);
         }
 
-        //실명검증 테스트베드
-//        try {
-//            KftcAccountRealNameResponse realNameResponse = kftcApiClient.requestAccountRealName(
-//                    connectedAccount.getAccessToken(),
-//                    request.getBankCode(),
-//                    request.getAccountNumber(),
-//                    request.getAccountHolderBirthDate(),
-//                    connectedAccount.getBankTranId()
-//            );
-//            if (!realNameResponse.isSuccess()) {
-//                String failReason = trimFailReason(realNameResponse.getRspMessage());
-//
-//                bankMapper.updateVerificationFailure(
-//                        userId,
-//                        request.getFintechUseNum(),
-//                        failReason
-//                );
-//
-//                throw new BusinessException(BANK_ACCOUNT_VERIFICATION_FAILED);
-//            }
-//
-//            boolean nameMatched = normalizeName(request.getAccountHolderName())
-//                    .equals(normalizeName(realNameResponse.getAccountHolderName()));
-//            boolean verified = realNameResponse.isSuccess() && nameMatched;
-//
-//            if (verified) {
-//                bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
-//                log.info("Settlement account verified. userId={}, fintechUseNum={}", userId, request.getFintechUseNum());
-//                bankCandidateStore.remove(userId);
-//                return;
-//            }
-//
-//            String failReason = realNameResponse.getRspMessage();
-//            if (!nameMatched) {
-//                failReason = "예금주명이 일치하지 않습니다.";
-//            }
-//
-//            bankMapper.updateVerificationFailure(
-//                    userId,
-//                    request.getFintechUseNum(),
-//                    trimFailReason(failReason)
-//            );
-//
-//            log.warn("Settlement account verification failed. userId={}, fintechUseNum={}",
-//                    userId, request.getFintechUseNum());
-//
-//            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_FAILED);
-//
-//        } catch (BusinessException e) {
-//            if (e.getErrorCode() == BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED) {
-//                bankMapper.updateVerificationFailure(
-//                        userId,
-//                        request.getFintechUseNum(),
-//                        trimFailReason(e.getErrorCode().getMessage())
-//                );
-//            }
-//            throw e;
-//        } catch (Exception e) {
-//            bankMapper.updateVerificationFailure(
-//                    userId,
-//                    request.getFintechUseNum(),
-//                    trimFailReason(e.getMessage())
-//            );
-//            throw new BusinessException(BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED);
-//        }
         bankMapper.updateVerificationSuccess(userId, request.getFintechUseNum());
-        bankCandidateStore.remove(userId);
+
+        bankSelectedStore.remove(userId);
+        bankSelectedStore.add(userId, request.getFintechUseNum());
     }
 
     @Transactional
@@ -189,18 +169,34 @@ public class BankService {
         bankMapper.deactivateSettlementAccountsByUserId(userId);
     }
 
-    @Transactional(readOnly = true)
+    /**
+     * 계좌 목록 조회 (표시 전용 — 엄격):
+     * - 활성 정산계좌(primary) 항상 포함
+     * - 이번 인증 후보 중 POST /settlement 완료된 것만 포함 (화이트리스트 필터)
+     * - 후보 전체 노출 없음 / DB fallback 없음 (레거시 미노출 보장)
+     */
     public List<BankAccountSummaryResponse> getAccounts(Long userId) {
+        BankAccount primary = bankMapper.findPrimaryByUserId(userId);
         List<BankCandidateDto> candidates = bankCandidateStore.findAll(userId);
-        if (candidates != null) {
-            return candidates.stream()
-                    .map(BankAccountSummaryResponse::fromCandidate)
-                    .toList();
+        Set<String> selected = bankSelectedStore.findAll(userId);
+
+        // fintechUseNum 기준 중복 제거, primary 우선
+        Map<String, BankAccountSummaryResponse> result = new LinkedHashMap<>();
+
+        if (primary != null) {
+            result.put(primary.getFintechUseNum(), BankAccountSummaryResponse.from(primary));
         }
-        log.warn("Bank candidate cache miss — falling back to DB. userId={}. Shown accounts may not reflect latest KFTC auth.", userId);
-        return bankMapper.findAllByUserId(userId).stream()
-                .map(BankAccountSummaryResponse::from)
-                .toList();
+
+        if (candidates != null) {
+            // 후보 전체 노출 금지: selected 화이트리스트만 통과
+            for (BankCandidateDto c : candidates) {
+                if (selected.contains(c.getFintechUseNum())) {
+                    result.putIfAbsent(c.getFintechUseNum(), BankAccountSummaryResponse.fromCandidate(c));
+                }
+            }
+        }
+
+        return new ArrayList<>(result.values());
     }
 
     @Transactional(readOnly = true)
@@ -212,6 +208,53 @@ public class BankService {
         return PrimaryBankAccountResponse.from(primary);
     }
 
+    // ── private helpers ──────────────────────────────────────────────────────
+
+    /**
+     * auth token Redis 캐시로 KFTC userInfo를 재조회해 후보 목록을 재구성한다.
+     * <p>
+     * null 반환: auth token 미보유(Redis miss) — caller가 DB fallback 처리.
+     * List 반환: KFTC 재조회 성공 (빈 리스트 포함).
+     * 예외 전파: KFTC API 장애 시 {@code BANK_ACCOUNT_CONNECT_REQUEST_FAILED} —
+     *            settlement은 전파, getAccounts는 흡수 후 DB fallback.
+     */
+    private List<BankCandidateDto> recoverCandidates(Long userId) {
+        Optional<BankAuthTokenDto> tokenOpt = bankAuthTokenStore.find(userId);
+        if (tokenOpt.isEmpty()) {
+            return null;
+        }
+        // auth token 보유 → KFTC 재조회. BusinessException(BANK007)은 그대로 전파.
+        BankAuthTokenDto stored = tokenOpt.get();
+        KftcTokenResponse syntheticToken = new KftcTokenResponse(
+                stored.getAccessToken(), stored.getRefreshToken(), stored.getUserSeqNo(),
+                null, null, null);
+
+        KftcUserInfoResponse userInfo = kftcApiClient.requestUserInfo(syntheticToken);
+
+        if (userInfo.getResList() == null || userInfo.getResList().isEmpty()) {
+            return List.of();
+        }
+
+        List<BankCandidateDto> recovered = userInfo.getResList().stream()
+                .map(dto -> BankCandidateDto.builder()
+                        .fintechUseNum(dto.getFintechUseNum())
+                        .bankTranId(dto.getBankTranId())
+                        .bankName(dto.getBankName())
+                        .accountAlias(dto.getAccountAlias())
+                        .accountNumMasked(dto.getAccountNumMasked())
+                        .accessToken(stored.getAccessToken())
+                        .refreshToken(stored.getRefreshToken())
+                        .build())
+                .toList();
+
+        return sanitizeCandidates(recovered);
+
+    }
+
+    /**
+     * fintechUseNum 기준으로 DB row가 있으면 KFTC 메타만 갱신, 없으면 신규 삽입.
+     * settlement 메타(account_type, is_primary, verification_*)는 updateBankAccount SQL이 건드리지 않는다.
+     */
     private void ensureKftcRowExists(Long userId, BankCandidateDto candidate) {
         BankAccount kftcRow = BankAccount.builder()
                 .userId(userId)
@@ -243,5 +286,33 @@ public class BankService {
             return "계좌 검증에 실패했습니다.";
         }
         return failReason.length() > 250 ? failReason.substring(0, 250) : failReason;
+    }
+
+    private List<BankCandidateDto> sanitizeCandidates(List<BankCandidateDto> raw) {
+        if (raw == null || raw.isEmpty()) return List.of();
+
+        // 순서 유지 + 중복 제거
+        Map<String, BankCandidateDto> dedup = new LinkedHashMap<>();
+
+        for (BankCandidateDto c : raw) {
+            if (c.getFintechUseNum() == null || c.getFintechUseNum().isBlank()) continue;
+
+            // 같은 은행 + 같은 마스킹 계좌는 1건만 노출
+            String key = nz(c.getBankName()) + "|" + nz(c.getAccountNumMasked());
+            if (key.equals("|")) {
+                key = c.getFintechUseNum();
+            }
+
+            // 키가 비정상이면 fintech 번호로 대체
+            if (key.equals("|")) key = c.getFintechUseNum();
+
+            dedup.putIfAbsent(key, c);
+        }
+
+        return new ArrayList<>(dedup.values());
+    }
+
+    private String nz(String v) {
+        return v == null ? "" : v.trim();
     }
 }

--- a/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
+++ b/src/main/java/pbl2/sub119/backend/common/error/ErrorCode.java
@@ -84,6 +84,7 @@ public enum ErrorCode {
     BANK_ACCOUNT_VERIFICATION_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BANK005", "계좌 실명 검증 요청에 실패했습니다."),
     BANK_PRIMARY_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "BANK006", "대표 정산 계좌가 없습니다."),
     BANK_ACCOUNT_CONNECT_REQUEST_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "BANK007", "계좌 연결 요청에 실패했습니다."),
+    BANK_AUTH_EXPIRED(HttpStatus.UNAUTHORIZED, "BANK008", "KFTC 인증이 만료되었습니다. 다시 인증 후 시도해 주세요."),
 
     // Party Operation
     PARTY_OPERATION_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY023", "파티 운영 정보가 존재하지 않습니다."),


### PR DESCRIPTION
## 배경
KFTC 콜백 이후 계좌 목록/정산계좌 등록 흐름에서 다음 문제가 있었습니다.
- 드롭다운에 과거(레거시) 계좌가 다시 노출됨
- 일부 케이스에서 정산계좌 등록이 실패함(후보/메타 row 보장 실패)

## 핵심 변경
### 1) 콜백 시 캐시 스냅샷 재구성
- `registerAccount()`에서 콜백 시작 시 기존 Redis 키 정리
  - `bank:candidates:{userId}`
  - `bank:auth:{userId}`
  - `bank:selected:{userId}`
- KFTC 응답 후보를 `sanitizeCandidates()` 후 Redis 후보 캐시에 저장
- auth token 캐시 저장(복구 경로용)

### 2) 계좌 목록 노출 정책 엄격화
- `getAccounts()`는 후보 전체 노출 금지
- `selected` 화이트리스트 기반으로만 후보 노출
- primary(활성 정산계좌)는 항상 포함

### 3) 정산계좌 등록 성공 경로 안정화
- `registerSettlementAccount()`에서 후보 miss 시 auth token 복구 경로 유지
- 복구 성공 시 `ensureKftcRowExists()`로 DB row 보장 후 메타 업데이트
- 등록 성공 후 `bank:selected`를 등록 계좌로 갱신

## 기대 동작
- 드롭다운에 레거시 계좌가 섞여 나오지 않음
- 콜백 직후 선택/등록 가능한 계좌는 현재 인증 스냅샷 기반으로 동작
- 등록 시 fintechUseNum 대상 row가 보장되어 메타 업데이트 실패 케이스 감소

## 검증
- `./gradlew compileJava -x test` 통과
- 수동 검증: 콜백 → 계좌조회 → 정산계좌 등록 → 재조회 정상 확인

## 영향 범위
- Backend: `BankService` 중심
- API 스펙 변경 없음(응답 형식 유지), 동작 정책만 정합화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 은행 계좌 등록 시 만료된 인증 복구 기능 추가
  * 캐시 기반 계좌 조회 시스템 도입

* **버그 수정**
  * 등록된 계좌만 표시되도록 계좌 목록 조회 개선

* **오류 처리**
  * KFTC 인증 만료 시 재인증 요청 메시지 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/144)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->