### PR TITLE
[Payment] 초기결제 이벤트 발행 시점 정합화 및 반복결제 트랜잭션 경계 안정화

### DIFF
--- a/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import pbl2.sub119.backend.party.event.PartyProvisionSetupCompletedEvent;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
@@ -44,6 +46,11 @@ public class PartyProvisionSetupCompletedEventListener {
         final PartyCycle partyCycle = initialPaymentCycleService.createInitialCycle(partyId);
         log.info("파티 결제일 확정 완료. partyId={}, partyCycleId={}", partyId, partyCycle.getId());
 
-        eventPublisher.publishEvent(new PaymentExecutionRequestedEvent(partyId, partyCycle.getId()));
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                eventPublisher.publishEvent(new PaymentExecutionRequestedEvent(partyId, partyCycle.getId()));
+            }
+        });
     }
 }

--- a/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -38,7 +39,7 @@ public class AutoPaymentService {
     private final TossPaymentClient tossPaymentClient;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void execute(Long partyId, Long partyCycleId) {
         PartyCycle cycle = partyCycleMapper.findById(partyCycleId);
         if (cycle == null) {


### PR DESCRIPTION
## 배경
초기/반복 결제 경로에서 이벤트 발행 시점과 트랜잭션 경계가 엇갈리며 다음 문제가 발생했습니다.

- 초기결제: `party_cycle(PAYMENT_PENDING)` 생성 후 결제 실행이 누락되어 `party_cycle_member_payment`가 생성되지 않는 케이스
- 반복결제(2회차+): 결제 완료 후 파티 도메인 상태 전이 체인(`PROCESSING -> RUNNING`) 고착 위험

원인은 결제 실행(`AutoPaymentService.execute`)의 트랜잭션 경계와
`PaymentExecutionRequestedEvent` 발행 시점이 일치하지 않아,
소비 시점에 cycle row 가시성이 보장되지 않거나 완료 이벤트 체인이 끊길 수 있었던 점입니다.

---

## 변경 내용

### 1) 결제 실행 트랜잭션 독립화
- `AutoPaymentService.execute(...)`
  - `@Transactional(propagation = Propagation.REQUIRES_NEW)` 적용/유지
- 목적:
  - 반복결제 경로에서 결제 실행/완료 이벤트 등록을 독립 커밋 경계로 처리

### 2) 초기결제 트리거 발행 시점 보정
- `PartyProvisionSetupCompletedEventListener`
  - `createInitialCycle()` 이후 `PaymentExecutionRequestedEvent`를 즉시 발행하지 않고
  - 해당 트랜잭션 `afterCommit` 시점에 발행되도록 조정
- 목적:
  - cycle 생성 커밋 이전 소비로 인한 `findById == null` 조기 종료 방지

---

## 기대 효과
- 초기결제:
  - `PAYMENT_PENDING` 생성 후 결제 실행 누락 방지
- 반복결제:
  - 완료 이벤트 체인 안정화로 `party_cycle PROCESSING -> RUNNING` 전이 보장
- 파티 도메인 후속 처리(이전 cycle CLOSED, 정산 트리거) 정상 동작

---

## 검증

### 수동 검증 시나리오
1. 파티 이용 정보 완료 후 초기결제 트리거
2. `party_cycle_member_payment` 생성 및 결제 실행 확인
3. 반복결제 스케줄러 트리거(billing_due_at 조정)
4. 상태 전이 확인:
   - 이전 cycle: `RUNNING -> CLOSED`
   - 신규 cycle: `PAYMENT_PENDING -> PROCESSING -> RUNNING`

### 확인 결과
- 실제 DB 결과:
  - cycle 1: `CLOSED`
  - cycle 2: `RUNNING`
- 자동결제/상태 전이 체인 정상 확인

---

## 영향 범위
- Payment 도메인 이벤트/트랜잭션 경계
- Party 도메인 상태 전이 트리거 입력 안정성
- API 스펙 변경 없음 (동작 안정화)

---

## 리스크 및 롤백
- 리스크:
  - 트랜잭션 경계 변경으로 이벤트 타이밍이 달라질 수 있음
- 롤백:
  - `execute` propagation 원복
  - 초기결제 이벤트 발행 시점 원복
  - 원복 시 반복결제/초기결제 재검증 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 결제 처리 중 트랜잭션 관리를 개선하여 이벤트 발행 안정성을 향상했습니다.
  * 자동 결제 실행 시 트랜잭션 격리를 강화하여 동시성 문제를 방지했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/146)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->