### PR TITLE
[Infra] #153 로컬 부하테스트 + 최소 모니터링(Prometheus/Grafana) 환경 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ out/
 ### VS Code ###
 .vscode/
 .claude/
+
+### Python ###
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+venv/

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,6 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -53,6 +51,10 @@ dependencies {
 
 	//mybatis
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.5'
+
+	// Actuator + Prometheus metrics
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
 	//Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,50 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=7d'
+      - '--web.enable-lifecycle'
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.3
+    container_name: grafana
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    ports:
+      - "8090:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+networks:
+  default:
+    name: monitoring

--- a/grafana/provisioning/datasources/prometheus.yml
+++ b/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: '5s'
+      httpMethod: POST

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,25 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    project: 'subsave'
+    env: 'local'
+
+scrape_configs:
+  - job_name: 'spring-boot'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    scrape_timeout: 4s
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          application: 'subsave-backend'
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'cadvisor'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['cadvisor:8080']

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,6 +21,19 @@ mybatis:
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
     map-underscore-to-camel-case: true
 
+management:
+  endpoints:
+    web:
+      base-path: /actuator
+      exposure:
+        include: health, info, prometheus, metrics
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+    tags:
+      application: subsave
+
 jwt:
   secret-key: ${JWT_SECRET_KEY}
   access-token-expiration-millis: 3600000


### PR DESCRIPTION
연관 이슈
•closes #153

배경
EC2 t3.micro 제약으로 운영 환경에서 대규모 부하테스트를 바로 수행하기 어려워, 로컬에서 성능 측정/병목 분석 가능한 최소 관측 환경을 먼저 구축함.

변경 사항
1) 모니터링 스택 구성
•docker-compose.monitoring.yml 추가
◦prometheus, grafana, cadvisor 구성
•prometheus.yml 추가
◦spring-boot(/actuator/prometheus), prometheus, cadvisor scrape 설정
•grafana/provisioning/datasources/prometheus.yml 추가
◦Prometheus datasource 자동 연결

2) 백엔드 메트릭 노출
•build.gradle
◦spring-boot-starter-actuator 추가
◦micrometer-registry-prometheus 추가
◦중복 spring-boot-starter-data-redis 정리
•src/main/resources/application-local.yml
◦/actuator 노출 설정 및 prometheus endpoint 활성화
◦application-prod.yml 미변경

3) 로컬 테스트 실행 구조 정리
•Python/Locust 스크립트는 저장소 외부 실행으로 분리
•.gitignore에 Python 산출물 패턴 추가(__pycache__/, .venv/ 등)

성능 테스트 결과(요약)
도메인 확장 GET 시나리오(상품/결원/유저/알림/정산/메일) 기준 대표 결과:
•RPS: 약 427.57
•Failure: 0%
•Aggregated p95: 80ms
•Aggregated p99: 180ms
참고: seed/* 요청은 테스트 준비용(전처리) 호출이므로 서비스 트래픽 지표와 분리 해석함.

범위 제외(의도적)
•운영 EC2 모니터링 배포
•Blue/Green 자동 전환 구축
•외부 의존 구간 부하테스트
◦결제사/빌링키 발급/오픈뱅킹 등

검증 항목
•[x] docker compose -f docker-compose.monitoring.yml config 정상
•[x] Prometheus targets spring-boot, prometheus, cadvisor UP 확인
•[x] /actuator/health UP 확인
•[x] Locust UI 기반 단계형 부하테스트 수행 및 결과 확보

후속 작업
1.POST/PATCH 시나리오(정산/파티) 단계적 확장
2.외부 연동 구간은 Stub/WireMock 기반으로 내부 병목 테스트 분리
3.운영 환경(EC2/Nginx/RDS) 재측정으로 로컬 결과 보정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 모니터링 시스템 추가: Prometheus, Grafana, cAdvisor를 통한 실시간 메트릭 수집 및 시각화
  * Actuator와 Prometheus 메트릭 통합으로 애플리케이션 성능 지표 노출

* **Chores**
  * Python 개발 환경 파일 지원 개선
  * Redis 의존성 구성 최적화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->