### PR TITLE
[Payment] 반복 결제 - 파티 운영 재설정 조정

### DIFF
--- a/src/main/java/pbl2/sub119/backend/payment/listener/DelayedRecurringPaymentTriggerListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/DelayedRecurringPaymentTriggerListener.java
@@ -1,0 +1,26 @@
+package pbl2.sub119.backend.payment.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import pbl2.sub119.backend.party.event.PartyProvisionSetupCompletedEvent;
+import pbl2.sub119.backend.payment.service.RecurringPaymentService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DelayedRecurringPaymentTriggerListener {
+
+    private final RecurringPaymentService recurringPaymentService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(PartyProvisionSetupCompletedEvent event) {
+        log.info("지연 반복결제 트리거 수신. partyId={}", event.partyId());
+        recurringPaymentService.triggerDelayedPaymentForParty(event.partyId());
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/PartyProvisionSetupCompletedEventListener.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.party.event.PartyProvisionSetupCompletedEvent;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
@@ -32,14 +33,21 @@ public class PartyProvisionSetupCompletedEventListener {
     public void handle(PartyProvisionSetupCompletedEvent event) {
         final Long partyId = event.partyId();
 
-        if (!partyPaymentReadinessService.isReady(partyId)) {
-            log.info("파티 결제 준비 미완료. partyId={}", partyId);
+        // cycle_no=1이 어떤 상태로든 존재하면 자동 초기결제 트리거 차단
+        // FAILED여도 자동 진행 금지 — InitialPaymentCycleService.createInitialCycle()이
+        // findNextCycleNo() 기반이므로 FAILED 파티에서 호출 시 cycle_no=2가 잘못 생성됨
+        PartyCycle existingInitialCycle = partyCycleMapper.findByPartyIdAndCycleNo(partyId, 1);
+        if (existingInitialCycle != null) {
+            if (existingInitialCycle.getStatus() == PartyCycleStatus.FAILED) {
+                log.warn("초기 결제 자동 재트리거 차단. partyId={}, reason=FAILED_INITIAL_CYCLE_EXISTS", partyId);
+            } else {
+                log.info("초기결제 사이클 이미 존재. partyId={}, status={}", partyId, existingInitialCycle.getStatus());
+            }
             return;
         }
 
-        // 초기 결제(cycle_no=1)가 이미 FAILED인 경우 자동 재트리거 차단 — 어드민 명시적 retry만 허용
-        if (partyCycleMapper.existsFailedInitialCycle(partyId)) {
-            log.warn("초기 결제 자동 재트리거 차단. partyId={}, reason=FAILED_INITIAL_CYCLE_EXISTS", partyId);
+        if (!partyPaymentReadinessService.isReady(partyId)) {
+            log.info("파티 결제 준비 미완료. partyId={}", partyId);
             return;
         }
 

--- a/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/RecurringPaymentService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.party.common.enumerated.OperationStatus;
+import pbl2.sub119.backend.party.cycle.service.PartyCycleService;
 import pbl2.sub119.backend.payment.dto.RecurringPaymentTarget;
 import pbl2.sub119.backend.payment.entity.PartyCycle;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
@@ -29,6 +30,7 @@ public class RecurringPaymentService {
     private final PartyCycleMapper partyCycleMapper;
     private final PaymentExecutionQueryMapper paymentExecutionQueryMapper;
     private final ApplicationEventPublisher eventPublisher;
+    private final PartyCycleService partyCycleService;
 
     @Transactional
     public void processDueCycles() {
@@ -50,6 +52,28 @@ public class RecurringPaymentService {
         }
     }
 
+    @Transactional
+    public void triggerDelayedPaymentForParty(Long partyId) {
+        RecurringPaymentTarget target = recurringPaymentQueryMapper.findRunningCycleByPartyId(
+                partyId,
+                PartyCycleStatus.RUNNING,
+                OperationStatus.ACTIVE
+        );
+
+        if (target == null) {
+            log.info("지연 결제 트리거 스킵. RUNNING 사이클 없음 또는 파티 비활성. partyId={}", partyId);
+            return;
+        }
+
+        LocalDateTime nextBillingDueAt = target.getBillingDueAt().plusMonths(1);
+        if (nextBillingDueAt.isAfter(LocalDateTime.now())) {
+            log.info("지연 결제 트리거 스킵. 다음 결제일 미도래. partyId={}, nextBillingDueAt={}", partyId, nextBillingDueAt);
+            return;
+        }
+
+        createNextCycleAndPublish(target, nextBillingDueAt);
+    }
+
     private void createNextCycleAndPublish(
             RecurringPaymentTarget target,
             LocalDateTime nextBillingDueAt
@@ -67,6 +91,12 @@ public class RecurringPaymentService {
         LocalDateTime now = LocalDateTime.now();
         // 다음 회차 snapshot은 반복회차 실제 과금 대상과 동일하게 ACTIVE MEMBER 수로 저장한다.
         int billableMemberCount = paymentExecutionQueryMapper.countActiveMembersByPartyId(target.getPartyId());
+
+        if (billableMemberCount == 0) {
+            log.info("과금 대상 0명. 파티 해체 판단으로 위임. partyId={}", target.getPartyId());
+            partyCycleService.dissolveAllLeaveReservedParty(target.getPartyId());
+            return;
+        }
 
         PartyCycle nextCycle = PartyCycle.builder()
                 .partyId(target.getPartyId())

--- a/src/main/resources/mapper/payment/RecurringPaymentQueryMapper.xml
+++ b/src/main/resources/mapper/payment/RecurringPaymentQueryMapper.xml
@@ -24,6 +24,11 @@
                  INNER JOIN party p ON p.id = pc.party_id
         WHERE pc.status = #{runningStatus}
           AND p.operation_status = #{activeOperationStatus}
+          AND NOT EXISTS (
+              SELECT 1 FROM party_operation po
+              WHERE po.party_id = pc.party_id
+                AND po.operation_status = 'RESET_REQUIRED'
+          )
         ORDER BY pc.id ASC
     </select>
 


### PR DESCRIPTION
관련 이슈
•closes #157

변경 배경
반복결제 흐름에서
1)과금 대상 0명일 때 일반 결제 실패로 끝나며 도메인 전이가 끊기는 문제,
2)provision RESET_REQUIRED 상태에서도 결제/사이클이 진행될 수 있는 문제
를 해결하기 위해 payment 도메인 로직을 보강했습니다.

주요 변경 사항
1) 과금 대상 0명 시 결제 실패 종료 대신 party 도메인 위임
•RecurringPaymentService에서 다음 사이클 생성 전 billableMemberCount 확인
•billableMemberCount == 0이면 결제 이벤트 발행/자동결제 진입하지 않고
partyCycleService.dissolveAllLeaveReservedParty(partyId) 호출 후 종료

2) RESET_REQUIRED 상태 반복결제 게이트
•RecurringPaymentQueryMapper.findRunningCycles에 RESET_REQUIRED 제외 조건 
추가
•provision이 RESET_REQUIRED인 파티는 반복결제 사이클 생성/결제요청 스킵

3) 지연 반복결제 재트리거 추가
•RecurringPaymentService.triggerDelayedPaymentForParty(Long partyId) 추가
•조건:
◦RUNNING 사이클 존재
◦party operation_status = ACTIVE
◦다음 결제일 도래
◦다음 사이클 미존재
•provision ACTIVE 여부는 해당 메서드에서 체크하지 않음

4) 이벤트 리스너 분리
•신규 DelayedRecurringPaymentTriggerListener 추가
•PartyProvisionSetupCompletedEvent를 AFTER_COMMIT + REQUIRES_NEW로 수신
•triggerDelayedPaymentForParty(partyId) 호출하여 지연 반복결제 재개

5) 기존 초기결제 리스너 가드 강화
•PartyProvisionSetupCompletedEventListener는 초기결제 전용으로 유지
•cycle_no=1 존재 시 자동 초기결제 트리거 차단(중복 생성/오진입 방지)
•초기결제 실패 복구는 자동 트리거가 아닌 명시적 retry 경로 사용 정책 유지

변경 파일
•payment/service/RecurringPaymentService.java
•payment/listener/DelayedRecurringPaymentTriggerListener.java (new)
•payment/listener/PartyProvisionSetupCompletedEventListener.java
•resources/mapper/payment/RecurringPaymentQueryMapper.xml

검증 결과
•./gradlew compileJava 성공 (EXIT_CODE=0)
•수동 검증(H2 + Swagger):
◦RESET_REQUIRED 상태에서 반복결제 사이클 증가 없음 확인
◦provision 재등록(setup) 후 지연 반복결제 재개 확인
◦사이클 중복 생성 없이 cycle_no 순차 증가 확인
•테스트 코드 변경 없음

비고
•billableMemberCount == 0은 결제 대상 없음 의미이며, 실제 해체 가능 여부 판단은 party 도메인에 위임됩니다.
•PartyProvisionSetupCompletedEvent는 초기 등록/재등록 모두에서 발행되므로, 초기결제/지연 반복결제 리스너 역할 분리를 유지했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 지연 반복결제 트리거 메커니즘을 추가하여 파티 프로비저닝 완료 후 자동으로 반복결제를 시작합니다.

* **Bug Fixes**
  * 초기 결제 사이클의 자동 재트리거 로직을 개선하여 중복 결제 시도를 방지합니다.
  * 반복결제 조회 시 리셋 필요 상태의 파티를 제외하는 필터링을 추가합니다.
  * 빌링 대상 회원이 없는 경우 파티 해체 처리를 자동화합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->