### PR TITLE
fix: provision/members 조회 시 현재 파티장 응답에서 제외

### DIFF
--- a/src/main/java/pbl2/sub119/backend/party/provision/mapper/PartyProvisionMemberMapper.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/mapper/PartyProvisionMemberMapper.java
@@ -27,7 +27,8 @@ public interface PartyProvisionMemberMapper {
     );
 
     List<PartyProvisionMemberResponse> findResponsesByPartyOperationId(
-            @Param("partyOperationId") Long partyOperationId
+            @Param("partyOperationId") Long partyOperationId,
+            @Param("hostUserId") Long hostUserId
     );
 
     List<PartyProvisionMemberResponse> findMemberEmailsByPartyId(

--- a/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionCommandService.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionCommandService.java
@@ -100,7 +100,7 @@ public class PartyProvisionCommandService {
                     partyId,
                     provision.getOperationType(),
                     provision.getOperationStatus(),
-                    partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId())
+                    partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId(), party.getHostUserId())
             );
         }
 
@@ -137,7 +137,7 @@ public class PartyProvisionCommandService {
                 partyId,
                 request.provisionType(),
                 ProvisionStatus.IN_PROGRESS,
-                partyProvisionMemberMapper.findResponsesByPartyOperationId(existingProvision.getId())
+                partyProvisionMemberMapper.findResponsesByPartyOperationId(existingProvision.getId(), party.getHostUserId())
         );
     }
 

--- a/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionQueryService.java
+++ b/src/main/java/pbl2/sub119/backend/party/provision/service/PartyProvisionQueryService.java
@@ -40,7 +40,7 @@ public class PartyProvisionQueryService {
         final PartyProvision provision = getProvisionByPartyId(partyId);
 
         final List<PartyProvisionMemberResponse> members =
-                partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId());
+                partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId(), party.getHostUserId());
 
         final int totalMemberCount = members.size();
 
@@ -78,7 +78,7 @@ public class PartyProvisionQueryService {
             return partyProvisionMemberMapper.findMemberEmailsByPartyId(partyId, party.getHostUserId());
         }
 
-        return partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId());
+        return partyProvisionMemberMapper.findResponsesByPartyOperationId(provision.getId(), party.getHostUserId());
     }
 
     // 본인에게 필요한 이용 정보 조회

--- a/src/main/resources/mapper/partyprovision/PartyProvisionMemberMapper.xml
+++ b/src/main/resources/mapper/partyprovision/PartyProvisionMemberMapper.xml
@@ -163,6 +163,7 @@
         FROM party_operation_member pom
                  INNER JOIN users u ON u.id = pom.user_id
         WHERE pom.party_operation_id = #{partyOperationId}
+          AND pom.user_id != #{hostUserId}
         ORDER BY pom.id ASC
     </select>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 파티 멤버 목록 조회 시 파티 호스트가 중복으로 표시되던 문제 해결

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->