### PR TITLE
[Payment[ retry 경로 비동기화 + 3-Phase TX 분리로 결제 병목 제거, fail-fast 상태복구 보강

### DIFF
--- a/src/main/java/pbl2/sub119/backend/payment/config/PaymentAsyncConfig.java
+++ b/src/main/java/pbl2/sub119/backend/payment/config/PaymentAsyncConfig.java
@@ -1,0 +1,69 @@
+package pbl2.sub119.backend.payment.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 결제 실행 비동기 설정.
+ *
+ * <p>성능 개선 목적:
+ * PaymentExecutionRequestedEvent 리스너를 비동기로 전환하여
+ * retry API 요청 스레드가 AutoPaymentService.execute() 완료를 기다리지 않도록 한다.
+ * 이를 통해 HTTP 응답을 즉시 반환하고 Tomcat 스레드 압박을 완화한다.
+ *
+ * <p>스레드 풀 설계 근거:
+ * - PG 호출은 I/O bound (stub: 120ms×N, 실 PG: 200~500ms+)
+ * - 고부하 시 약 121 retry/s → 동시 execute 수 ≈ 121 × (5ms Phase1+5ms Phase3) / 1000 ≈ 2
+ *   (3-Phase 분리 후 접속 보유 시간이 ~10ms이므로 DB 병목 해소)
+ * - PG I/O 동시 수 ≈ 121 × 0.6s = ~73 → corePoolSize 40 설정
+ * - RejectedExecutionHandler: CallerRunsPolicy → 큐 포화 시 호출 스레드(Tomcat)에서 동기 실행
+ *   (degraded 모드로 동작, OOM/무한 큐 방지)
+ */
+@Slf4j
+@Configuration
+@EnableAsync
+public class PaymentAsyncConfig implements AsyncConfigurer {
+
+    /**
+     * 결제 실행 전용 스레드풀.
+     * 이름: "payment-exec-N" (모니터링/덤프에서 식별 가능)
+     */
+    @Bean("paymentExecutor")
+    public Executor paymentExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(40);
+        executor.setMaxPoolSize(80);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("payment-exec-");
+        // 큐 포화 시 CallerRuns: 무한 큐/거절 대신 호출 스레드에서 처리 (서킷 브레이커 역할)
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(30);
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * 비동기 메서드에서 발생한 미처리 예외 로깅.
+     * execute()에서 예외 발생 시 HTTP 응답은 이미 204로 반환된 상태이므로
+     * 로그로 기록 후 마감 처리기(DeadlinePaymentService)에 복구를 위임한다.
+     */
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncUncaughtExceptionHandler() {
+            @Override
+            public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+                log.error("[비동기 결제 실행 미처리 예외] method={}, params={}", method.getName(), params, ex);
+            }
+        };
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/payment/listener/PaymentExecutionRequestedEventListener.java
+++ b/src/main/java/pbl2/sub119/backend/payment/listener/PaymentExecutionRequestedEventListener.java
@@ -3,10 +3,41 @@ package pbl2.sub119.backend.payment.listener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import pbl2.sub119.backend.payment.event.PaymentExecutionRequestedEvent;
 import pbl2.sub119.backend.payment.service.AutoPaymentService;
 
+/**
+ * 결제 실행 요청 이벤트 리스너.
+ *
+ * <h2>성능 개선: 동기 → @Async 비동기 실행</h2>
+ * <pre>
+ * 변경 전: retry() 스레드 → afterCommit() → publishEvent() → handle() 동기 실행
+ *          → execute() 전체(PG I/O ~600ms) 완료까지 HTTP 스레드 블로킹
+ *          → Tomcat 스레드 고갈, p99 급등
+ *
+ * 변경 후: retry() 스레드 → afterCommit() → publishEvent()
+ *          → paymentExecutor 큐 투입 후 즉시 리턴 (~3ms)
+ *          → execute()는 paymentExecutor 스레드풀에서 독립 실행
+ * </pre>
+ *
+ * <h2>이벤트 유실 및 복구 경로</h2>
+ * JVM 크래시 시 큐에 투입된 작업이 유실될 수 있다 (변경 전도 afterCommit 이후 크래시 시 동일).
+ * 완전한 내구성이 필요하면 Outbox 패턴 도입이 필요하다.
+ * 현재 복구 경로: party_cycle.status = PAYMENT_PENDING 잔존 레코드를
+ * {@link pbl2.sub119.backend.payment.service.DeadlinePaymentService}가 GRACE_HOURS(24h) 후 FAILED 처리.
+ * 이후 어드민이 /retry 재호출로 수동 복구 가능.
+ *
+ * <h2>중복 실행 방지</h2>
+ * execute() Phase1의 claimCycle CAS(PAYMENT_PENDING→PROCESSING)가
+ * 동일 partyCycleId에 대해 단 한 번만 성공하므로, @Async로 인한 중복 처리는 없다.
+ *
+ * <h2>CallerRunsPolicy 발동 조건</h2>
+ * paymentExecutor: corePool=40, maxPool=80, queue=200.
+ * 동시 작업이 280(= maxPool + queue)을 초과하면 publishEvent() 호출 스레드(Tomcat)에서
+ * execute()를 동기 실행한다 → 일시적 p99 상승 가능.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -14,9 +45,10 @@ public class PaymentExecutionRequestedEventListener {
 
     private final AutoPaymentService autoPaymentService;
 
+    @Async("paymentExecutor")
     @EventListener
     public void handle(PaymentExecutionRequestedEvent event) {
-        log.info("자동결제 실행 시작. partyId={}, partyCycleId={}",
+        log.info("자동결제 실행 시작 [비동기]. partyId={}, partyCycleId={}",
                 event.partyId(), event.partyCycleId());
 
         autoPaymentService.execute(event.partyId(), event.partyCycleId());

--- a/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMemberPaymentMapper.java
+++ b/src/main/java/pbl2/sub119/backend/payment/mapper/PartyCycleMemberPaymentMapper.java
@@ -59,5 +59,30 @@ public interface PartyCycleMemberPaymentMapper {
 
     List<Long> findDeadlineExceededCycleIds(@Param("deadline") LocalDateTime deadline);
 
+    /**
+     * 성능 개선: 기존 N회 개별 insertIfAbsent → 1회 배치 INSERT IGNORE.
+     * 멱등성: INSERT IGNORE로 중복 레코드 생성 방지 (기존 insertIfAbsent와 동일 의미).
+     *
+     * @param payments 초기화할 멤버 결제 레코드 목록 (비어 있으면 호출하지 않을 것)
+     */
+    int batchInsertIfAbsent(@Param("payments") List<PartyCycleMemberPayment> payments);
+
+    /**
+     * fail-fast PG 실패 시 PG 미호출 멤버 복구.
+     *
+     * <p>Phase1에서 선점(PAYMENT_PENDING→PROCESSING)했으나 fail-fast로 PG를 호출하지 못한
+     * 멤버를 PAYMENT_PENDING으로 되돌린다.
+     * 기존 순차 루프 코드에서는 미처리 멤버가 자동으로 PAYMENT_PENDING에 남았으므로,
+     * 이 메서드는 그 동작을 명시적으로 복원한다.
+     *
+     * <p>WHERE status='PROCESSING' 조건으로 이미 PAID/FAILED 상태인 멤버에게는 영향 없음.
+     *
+     * @param partyCycleId 대상 사이클 ID
+     * @param memberIds    복구할 partyMemberId 목록
+     */
+    int resetProcessingToPaymentPending(
+            @Param("partyCycleId") Long partyCycleId,
+            @Param("memberIds") List<Long> memberIds);
+
     List<PartyCycleMemberPayment> findByCycleId(@Param("partyCycleId") Long partyCycleId);
 }

--- a/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
+++ b/src/main/java/pbl2/sub119/backend/payment/service/AutoPaymentService.java
@@ -1,13 +1,17 @@
 package pbl2.sub119.backend.payment.service;
 
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallbackWithoutResult;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import pbl2.sub119.backend.common.enumerated.BillingKeyStatus;
 import pbl2.sub119.backend.common.enumerated.PartyCycleStatus;
 import pbl2.sub119.backend.common.enumerated.PartyMemberStatus;
@@ -23,12 +27,15 @@ import pbl2.sub119.backend.payment.event.PartyCyclePaymentFailedEvent;
 import pbl2.sub119.backend.payment.mapper.PartyCycleMemberPaymentMapper;
 import pbl2.sub119.backend.payment.mapper.PartyCycleMapper;
 import pbl2.sub119.backend.payment.mapper.PaymentExecutionQueryMapper;
-import pbl2.sub119.backend.toss.client.TossPaymentClient;
+import pbl2.sub119.backend.toss.client.PaymentGatewayClient;
 import pbl2.sub119.backend.toss.dto.request.TossBillingPaymentRequest;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -38,48 +45,96 @@ public class AutoPaymentService {
     private final PartyCycleMapper partyCycleMapper;
     private final PaymentExecutionQueryMapper paymentExecutionQueryMapper;
     private final PartyCycleMemberPaymentMapper memberPaymentMapper;
-    private final TossPaymentClient tossPaymentClient;
+    private final PaymentGatewayClient paymentGatewayClient;
     private final ApplicationEventPublisher eventPublisher;
+    private final PlatformTransactionManager transactionManager;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+
+    private TransactionTemplate requiresNewTx;
+
+    @PostConstruct
+    void initTransactionTemplate() {
+        this.requiresNewTx = new TransactionTemplate(transactionManager);
+        this.requiresNewTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    }
+
+
     public void execute(Long partyId, Long partyCycleId) {
-        PartyCycle cycle = partyCycleMapper.findById(partyCycleId);
-        if (cycle == null) {
-            return;
-        }
 
-        if (!claimCycle(partyCycleId)) {
-            log.info("자동결제 선점 실패. partyId={}, partyCycleId={}", partyId, partyCycleId);
-            return;
-        }
 
-        if (cycle.getCycleNo() > 1) {
-            refreshRecurringSnapshot(partyId, partyCycleId);
-        }
+        final ClaimResult claimResult = requiresNewTx.execute(status -> {
 
-        PaymentTargets paymentTargets = resolvePaymentTargets(partyId, partyCycleId, cycle);
-
-        if (paymentTargets.expectedMemberCount() == 0
-                || paymentTargets.targets().size() != paymentTargets.expectedMemberCount()) {
-            failCycleAndPublish(partyId, partyCycleId, "INVALID_CHARGE_TARGET_COUNT");
-            return;
-        }
-
-        initMemberPayments(partyId, partyCycleId, paymentTargets.targets());
-
-        for (PaymentChargeTarget target : paymentTargets.targets()) {
-            int claimed = memberPaymentMapper.compareAndUpdateStatus(
-                    partyCycleId, target.getMemberId(),
-                    MemberPaymentStatus.PAYMENT_PENDING, MemberPaymentStatus.PROCESSING);
-
-            if (claimed == 0) {
-                log.warn("멤버 결제 선점 실패(이미 처리됨). partyCycleId={}, memberId={}",
-                        partyCycleId, target.getMemberId());
-                continue;
+            PartyCycle cycle = partyCycleMapper.findById(partyCycleId);
+            if (cycle == null) {
+                return null;
             }
 
+            if (!claimCycle(partyCycleId)) {
+                log.info("자동결제 선점 실패. partyId={}, partyCycleId={}", partyId, partyCycleId);
+                return null;
+            }
+
+            if (cycle.getCycleNo() > 1) {
+                refreshRecurringSnapshot(partyId, partyCycleId);
+            }
+
+            PaymentTargets paymentTargets = resolvePaymentTargets(partyId, partyCycleId, cycle);
+
+            if (paymentTargets.expectedMemberCount() == 0
+                    || paymentTargets.targets().size() != paymentTargets.expectedMemberCount()) {
+                failCycleAndPublish(partyId, partyCycleId, "INVALID_CHARGE_TARGET_COUNT");
+                return null;
+            }
+
+            batchInitMemberPayments(partyId, partyCycleId, paymentTargets.targets());
+
+            List<PaymentChargeTarget> claimedTargets = new ArrayList<>();
+            for (PaymentChargeTarget target : paymentTargets.targets()) {
+                int claimed = memberPaymentMapper.compareAndUpdateStatus(
+                        partyCycleId, target.getMemberId(),
+                        MemberPaymentStatus.PAYMENT_PENDING, MemberPaymentStatus.PROCESSING);
+                if (claimed == 1) {
+                    claimedTargets.add(target);
+                } else {
+                    log.warn("멤버 결제 선점 실패(이미 처리됨). partyCycleId={}, memberId={}",
+                            partyCycleId, target.getMemberId());
+                }
+            }
+
+            return new ClaimResult(cycle, claimedTargets, paymentTargets.expectedMemberCount());
+        });
+
+        if (claimResult == null) {
+
+            return;
+        }
+
+
+        final List<MemberPaymentResult> pgResults =
+                executePgCalls(partyId, partyCycleId, claimResult.claimedTargets());
+
+        try {
+            requiresNewTx.execute(new TransactionCallbackWithoutResult() {
+                @Override
+                protected void doInTransactionWithoutResult(TransactionStatus status) {
+                    recordResultsAndFinalize(partyId, partyCycleId, claimResult, pgResults);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Phase3 결제 결과 기록 실패. partyCycleId={}. 마감 처리기에 의해 복구 예정.",
+                    partyCycleId, e);
+        }
+    }
+
+
+    private List<MemberPaymentResult> executePgCalls(
+            Long partyId, Long partyCycleId, List<PaymentChargeTarget> targets) {
+
+        List<MemberPaymentResult> results = new ArrayList<>(targets.size());
+
+        for (PaymentChargeTarget target : targets) {
             try {
-                var response = tossPaymentClient.executeBillingPayment(
+                var response = paymentGatewayClient.executeBillingPayment(
                         target.getBillingKey(),
                         new TossBillingPaymentRequest(
                                 target.getCustomerKey(),
@@ -88,35 +143,57 @@ public class AutoPaymentService {
                                 "Submate 파티 이용료"),
                         createIdempotencyKey(target)
                 );
-
-                memberPaymentMapper.markPaid(
-                        partyCycleId, target.getMemberId(),
-                        response.paymentKey(), LocalDateTime.now());
-
-                registerAfterCommit(() ->
-                        eventPublisher.publishEvent(
-                                new PaymentSucceededEvent(partyId, partyCycleId, target.getUserId()))
-                );
+                results.add(MemberPaymentResult.success(target, response.paymentKey(), LocalDateTime.now()));
 
             } catch (Exception e) {
-                log.error("자동결제 실패. partyId={}, partyCycleId={}, memberId={}",
+                log.error("자동결제 PG 호출 실패. partyId={}, partyCycleId={}, memberId={}",
                         partyId, partyCycleId, target.getMemberId(), e);
+                results.add(MemberPaymentResult.failure(
+                        target, e.getMessage(), e.getClass().getSimpleName(), LocalDateTime.now()));
+                // 기존 동작 유지: 첫 실패 시 이후 멤버 호출 중단
+                break;
+            }
+        }
 
-                memberPaymentMapper.markFailed(
-                        partyCycleId, target.getMemberId(),
-                        e.getMessage(), e.getClass().getSimpleName(), LocalDateTime.now());
+        return results;
+    }
 
+
+    private void recordResultsAndFinalize(
+            Long partyId, Long partyCycleId,
+            ClaimResult claimResult, List<MemberPaymentResult> pgResults) {
+
+        for (MemberPaymentResult result : pgResults) {
+            if (result.success()) {
+                memberPaymentMapper.markPaid(
+                        partyCycleId, result.target().getMemberId(),
+                        result.paymentKey(), result.paidAt());
+
+                final Long succeededUserId = result.target().getUserId();
                 registerAfterCommit(() ->
                         eventPublisher.publishEvent(
-                                new PaymentFailedEvent(partyId, partyCycleId, target.getUserId()))
+                                new PaymentSucceededEvent(partyId, partyCycleId, succeededUserId))
                 );
+
+            } else {
+                memberPaymentMapper.markFailed(
+                        partyCycleId, result.target().getMemberId(),
+                        result.failureReason(), result.failureCode(), result.failedAt());
+
+                final Long failedUserId = result.target().getUserId();
+                registerAfterCommit(() ->
+                        eventPublisher.publishEvent(
+                                new PaymentFailedEvent(partyId, partyCycleId, failedUserId))
+                );
+
+                resetUnprocessedClaimedMembers(partyCycleId, claimResult.claimedTargets(), pgResults);
+
 
                 failCycleAndPublish(partyId, partyCycleId, "PAYMENT_API_FAILED");
                 return;
             }
         }
 
-        // DB 기준 최종 완료 판정 (claimed==0 skip 케이스 포함)
         int nonPaidCount = memberPaymentMapper.countNonPaid(partyCycleId);
         if (nonPaidCount > 0) {
             log.warn("미완료 멤버 존재. partyId={}, partyCycleId={}, nonPaidCount={}",
@@ -125,36 +202,26 @@ public class AutoPaymentService {
             return;
         }
 
-        // DB 기준 실제 PAID 카운트 (targets.size() 대신 DB 재조회)
-        int paidCount  = memberPaymentMapper.countByStatus(partyCycleId, MemberPaymentStatus.PAID);
-        int totalCount = paymentTargets.expectedMemberCount();
+
+        int paidCount = memberPaymentMapper.countByStatus(partyCycleId, MemberPaymentStatus.PAID);
+        int totalCount = claimResult.expectedMemberCount();
+
         registerAfterCommit(() ->
                 eventPublisher.publishEvent(new PartyCyclePaymentCompletedEvent(
-                        partyId, partyCycleId, cycle.getCycleNo(), paidCount, totalCount))
+                        partyId, partyCycleId, claimResult.cycle().getCycleNo(), paidCount, totalCount))
         );
 
         log.info("자동결제 전원 성공. partyId={}, partyCycleId={}", partyId, partyCycleId);
     }
 
-    private void initMemberPayments(Long partyId, Long partyCycleId,
-                                    List<PaymentChargeTarget> targets) {
-        LocalDateTime now = LocalDateTime.now();
-        for (PaymentChargeTarget target : targets) {
-            memberPaymentMapper.insertIfAbsent(
-                    PartyCycleMemberPayment.builder()
-                            .partyCycleId(partyCycleId)
-                            .partyId(partyId)
-                            .partyMemberId(target.getMemberId())
-                            .userId(target.getUserId())
-                            .amount(target.getAmount())
-                            .status(MemberPaymentStatus.PAYMENT_PENDING)
-                            .idempotencyKey(createIdempotencyKey(target))
-                            .createdAt(now)
-                            .updatedAt(now)
-                            .build()
-            );
-        }
+
+    private boolean claimCycle(Long partyCycleId) {
+        return partyCycleMapper.compareAndUpdateStatus(
+                partyCycleId,
+                PartyCycleStatus.PAYMENT_PENDING,
+                PartyCycleStatus.PROCESSING) == 1;
     }
+
 
     private void refreshRecurringSnapshot(Long partyId, Long partyCycleId) {
         int activeMemberCount = paymentExecutionQueryMapper.countActiveMembersByPartyId(partyId);
@@ -168,37 +235,8 @@ public class AutoPaymentService {
         }
     }
 
-    // PAYMENT_PENDING → PROCESSING 만 허용 (FAILED → PROCESSING 자동 재시도 금지)
-    private boolean claimCycle(Long partyCycleId) {
-        return partyCycleMapper.compareAndUpdateStatus(
-                partyCycleId,
-                PartyCycleStatus.PAYMENT_PENDING,
-                PartyCycleStatus.PROCESSING) == 1;
-    }
 
-    // CAS 성공(1회) 시에만 afterCommit 이벤트 등록 → 멱등성 보장
-    private void failCycleAndPublish(Long partyId, Long partyCycleId, String reason) {
-        int updated = partyCycleMapper.compareAndUpdateStatus(
-                partyCycleId, PartyCycleStatus.PROCESSING, PartyCycleStatus.FAILED);
-
-        if (updated != 1) {
-            log.warn("party_cycle FAILED 전이 실패(이미 처리됨). partyCycleId={}", partyCycleId);
-            return;
-        }
-
-        // failedCount/pendingCount: DB 재조회 기준 (루프 변수 금지)
-        // pendingCount: PAYMENT_PENDING + PROCESSING 합산 (장애 시 PROCESSING 잔존 포함)
-        int failedCount  = memberPaymentMapper.countByStatus(partyCycleId, MemberPaymentStatus.FAILED);
-        int pendingCount = memberPaymentMapper.countPendingOrProcessing(partyCycleId);
-
-        registerAfterCommit(() ->
-                eventPublisher.publishEvent(new PartyCyclePaymentFailedEvent(
-                        partyId, partyCycleId, failedCount, pendingCount, reason))
-        );
-    }
-
-    private PaymentTargets resolvePaymentTargets(Long partyId, Long partyCycleId,
-                                                  PartyCycle cycle) {
+    private PaymentTargets resolvePaymentTargets(Long partyId, Long partyCycleId, PartyCycle cycle) {
         if (cycle.getCycleNo() == 1) {
             int expected = paymentExecutionQueryMapper.countMembersByStatus(
                     partyId, PartyRole.MEMBER, PartyMemberStatus.PENDING);
@@ -212,6 +250,70 @@ public class AutoPaymentService {
         List<PaymentChargeTarget> targets = paymentExecutionQueryMapper.findRecurringChargeTargets(
                 partyId, partyCycleId, PartyRole.MEMBER, BillingKeyStatus.ACTIVE);
         return new PaymentTargets(expected, targets);
+    }
+
+
+    private void batchInitMemberPayments(Long partyId, Long partyCycleId,
+                                          List<PaymentChargeTarget> targets) {
+        if (targets.isEmpty()) return;
+
+        LocalDateTime now = LocalDateTime.now();
+        List<PartyCycleMemberPayment> payments = targets.stream()
+                .map(target -> PartyCycleMemberPayment.builder()
+                        .partyCycleId(partyCycleId)
+                        .partyId(partyId)
+                        .partyMemberId(target.getMemberId())
+                        .userId(target.getUserId())
+                        .amount(target.getAmount())
+                        .status(MemberPaymentStatus.PAYMENT_PENDING)
+                        .idempotencyKey(createIdempotencyKey(target))
+                        .createdAt(now)
+                        .updatedAt(now)
+                        .build())
+                .toList();
+
+        memberPaymentMapper.batchInsertIfAbsent(payments);
+    }
+
+
+    private void resetUnprocessedClaimedMembers(
+            Long partyCycleId,
+            List<PaymentChargeTarget> claimedTargets,
+            List<MemberPaymentResult> pgResults) {
+
+        Set<Long> processedIds = pgResults.stream()
+                .map(r -> r.target().getMemberId())
+                .collect(Collectors.toSet());
+
+        List<Long> unprocessedIds = claimedTargets.stream()
+                .map(PaymentChargeTarget::getMemberId)
+                .filter(id -> !processedIds.contains(id))
+                .toList();
+
+        if (!unprocessedIds.isEmpty()) {
+            memberPaymentMapper.resetProcessingToPaymentPending(partyCycleId, unprocessedIds);
+            log.info("fail-fast 미처리 멤버 PAYMENT_PENDING 복구. partyCycleId={}, memberIds={}",
+                    partyCycleId, unprocessedIds);
+        }
+    }
+
+
+    private void failCycleAndPublish(Long partyId, Long partyCycleId, String reason) {
+        int updated = partyCycleMapper.compareAndUpdateStatus(
+                partyCycleId, PartyCycleStatus.PROCESSING, PartyCycleStatus.FAILED);
+
+        if (updated != 1) {
+            log.warn("party_cycle FAILED 전이 실패(이미 처리됨). partyCycleId={}", partyCycleId);
+            return;
+        }
+
+        int failedCount  = memberPaymentMapper.countByStatus(partyCycleId, MemberPaymentStatus.FAILED);
+        int pendingCount = memberPaymentMapper.countPendingOrProcessing(partyCycleId);
+
+        registerAfterCommit(() ->
+                eventPublisher.publishEvent(new PartyCyclePaymentFailedEvent(
+                        partyId, partyCycleId, failedCount, pendingCount, reason))
+        );
     }
 
     private void registerAfterCommit(Runnable action) {
@@ -234,6 +336,33 @@ public class AutoPaymentService {
         return "settle:party:" + target.getPartyId()
                 + ":cycle:" + target.getPartyCycleId()
                 + ":user:" + target.getUserId();
+    }
+
+
+    private record ClaimResult(
+            PartyCycle cycle,
+            List<PaymentChargeTarget> claimedTargets,
+            int expectedMemberCount
+    ) {}
+
+
+    private record MemberPaymentResult(
+            PaymentChargeTarget target,
+            boolean success,
+            String paymentKey,
+            LocalDateTime paidAt,
+            String failureReason,
+            String failureCode,
+            LocalDateTime failedAt
+    ) {
+        static MemberPaymentResult success(PaymentChargeTarget t, String pk, LocalDateTime paidAt) {
+            return new MemberPaymentResult(t, true, pk, paidAt, null, null, null);
+        }
+
+        static MemberPaymentResult failure(PaymentChargeTarget t,
+                                           String reason, String code, LocalDateTime failedAt) {
+            return new MemberPaymentResult(t, false, null, null, reason, code, failedAt);
+        }
     }
 
     private record PaymentTargets(int expectedMemberCount, List<PaymentChargeTarget> targets) {}

--- a/src/main/java/pbl2/sub119/backend/toss/client/PaymentGatewayClient.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/PaymentGatewayClient.java
@@ -1,0 +1,16 @@
+package pbl2.sub119.backend.toss.client;
+
+import pbl2.sub119.backend.toss.dto.request.TossBillingAuthRequest;
+import pbl2.sub119.backend.toss.dto.request.TossBillingPaymentRequest;
+import pbl2.sub119.backend.toss.dto.response.TossBillingAuthResponse;
+import pbl2.sub119.backend.toss.dto.response.TossBillingPaymentResponse;
+
+public interface PaymentGatewayClient {
+    TossBillingAuthResponse issueBillingKey(TossBillingAuthRequest request);
+
+    TossBillingPaymentResponse executeBillingPayment(
+            String billingKey,
+            TossBillingPaymentRequest request,
+            String idempotencyKey
+    );
+}

--- a/src/main/java/pbl2/sub119/backend/toss/client/StubPaymentClient.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/StubPaymentClient.java
@@ -1,0 +1,61 @@
+package pbl2.sub119.backend.toss.client;
+
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import pbl2.sub119.backend.common.error.ErrorCode;
+import pbl2.sub119.backend.toss.dto.request.TossBillingAuthRequest;
+import pbl2.sub119.backend.toss.dto.request.TossBillingPaymentRequest;
+import pbl2.sub119.backend.toss.dto.response.TossBillingAuthResponse;
+import pbl2.sub119.backend.toss.dto.response.TossBillingPaymentResponse;
+import pbl2.sub119.backend.toss.exception.PaymentException;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "payment", name = "provider", havingValue = "stub")
+public class StubPaymentClient implements PaymentGatewayClient {
+
+    private final StubPaymentProperties props;
+
+    @Override
+    public TossBillingAuthResponse issueBillingKey(TossBillingAuthRequest request) {
+        sleep();
+        maybeFail(ErrorCode.PAYMENT_BILLING_KEY_ISSUE_FAILED);
+        return new TossBillingAuthResponse(
+                "stub-bk-" + UUID.randomUUID(),
+                request.customerKey(),
+                "STUB_CARD",
+                "1234-****-****-5678"
+        );
+    }
+
+    @Override
+    public TossBillingPaymentResponse executeBillingPayment(
+            String billingKey,
+            TossBillingPaymentRequest request,
+            String idempotencyKey
+    ) {
+        sleep();
+        maybeFail(ErrorCode.PAYMENT_BILLING_EXECUTION_FAILED);
+        return new TossBillingPaymentResponse(
+                "stub-pay-" + UUID.randomUUID(),
+                request.orderId(),
+                "DONE"
+        );
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(Math.max(0, props.getDelayMs()));
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    private void maybeFail(ErrorCode errorCode) {
+        if (ThreadLocalRandom.current().nextDouble() < props.getFailRate()) {
+            throw new PaymentException(errorCode);
+        }
+    }
+}

--- a/src/main/java/pbl2/sub119/backend/toss/client/StubPaymentProperties.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/StubPaymentProperties.java
@@ -1,0 +1,15 @@
+package pbl2.sub119.backend.toss.client;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "payment.stub")
+public class StubPaymentProperties {
+    private int delayMs = 120;
+    private double failRate = 0.0;
+}

--- a/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
+++ b/src/main/java/pbl2/sub119/backend/toss/client/TossPaymentClient.java
@@ -2,6 +2,7 @@ package pbl2.sub119.backend.toss.client;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -19,7 +20,8 @@ import java.util.Base64;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class TossPaymentClient {
+@ConditionalOnProperty(prefix = "payment", name = "provider", havingValue = "toss", matchIfMissing = true)
+public class TossPaymentClient implements PaymentGatewayClient {
 
     private final TossPaymentProperties tossPaymentProperties;
     private final WebClient webClient;
@@ -29,6 +31,7 @@ public class TossPaymentClient {
         return "Basic " + Base64.getEncoder().encodeToString(credentials.getBytes());
     }
 
+    @Override
     public TossBillingAuthResponse issueBillingKey(TossBillingAuthRequest request) {
         validateBillingAuthRequest(request);
 
@@ -49,6 +52,7 @@ public class TossPaymentClient {
         }
     }
 
+    @Override
     public TossBillingPaymentResponse executeBillingPayment(
             String billingKey,
             TossBillingPaymentRequest request,

--- a/src/main/java/pbl2/sub119/backend/toss/service/BillingKeyService.java
+++ b/src/main/java/pbl2/sub119/backend/toss/service/BillingKeyService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import pbl2.sub119.backend.auth.entity.Accessor;
 import pbl2.sub119.backend.common.enumerated.BillingKeyStatus;
 import pbl2.sub119.backend.common.error.ErrorCode;
-import pbl2.sub119.backend.toss.client.TossPaymentClient;
+import pbl2.sub119.backend.toss.client.PaymentGatewayClient;
 import pbl2.sub119.backend.toss.dto.request.BillingKeyIssueRequest;
 import pbl2.sub119.backend.toss.dto.request.TossBillingAuthRequest;
 import pbl2.sub119.backend.toss.dto.response.BillingKeyInfoResponse;
@@ -23,7 +23,7 @@ import pbl2.sub119.backend.toss.mapper.BillingKeyMapper;
 @RequiredArgsConstructor
 public class BillingKeyService {
 
-    private final TossPaymentClient tossPaymentClient;
+    private final PaymentGatewayClient paymentGatewayClient;
     private final BillingKeyMapper billingKeyMapper;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -37,7 +37,7 @@ public class BillingKeyService {
 
         String customerKey = "submate-" + userId;
 
-        TossBillingAuthResponse response = tossPaymentClient.issueBillingKey(
+        TossBillingAuthResponse response = paymentGatewayClient.issueBillingKey(
                 new TossBillingAuthRequest(request.authKey(), customerKey)
         );
 
@@ -74,7 +74,7 @@ public class BillingKeyService {
 
         log.info("빌링키 변경 요청. userId={}, customerKey={}", userId, customerKey);
 
-        TossBillingAuthResponse response = tossPaymentClient.issueBillingKey(
+        TossBillingAuthResponse response = paymentGatewayClient.issueBillingKey(
                 new TossBillingAuthRequest(request.authKey(), customerKey)
         );
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,6 +4,12 @@ spring:
     driver-class-name: org.h2.Driver
     username: sa
     password:
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 5000
+      validation-timeout: 2000
+      leak-detection-threshold: 20000
 
   h2:
     console:
@@ -63,3 +69,15 @@ oauth:
 geoip:
   ip-api:
     base-url: http://ip-api.com
+
+payment:
+  provider: stub
+  stub:
+    delay-ms: 120
+    fail-rate: 0.0
+
+server:
+  tomcat:
+    threads:
+      max: 200
+    accept-count: 500

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -48,3 +48,6 @@ kftc:
 toss:
   secret-key: ${TOSS_SECRET_KEY}
   base-url: https://api.tosspayments.com
+
+payment:
+  provider: toss

--- a/src/main/resources/mapper/payment/PartyCycleMemberPaymentMapper.xml
+++ b/src/main/resources/mapper/payment/PartyCycleMemberPaymentMapper.xml
@@ -143,4 +143,53 @@
         ORDER BY id ASC
     </select>
 
+    <!--
+        fail-fast 복구: Phase1에서 선점(PROCESSING)했으나 PG 미호출 멤버를 PAYMENT_PENDING으로 복원.
+        WHERE status='PROCESSING' 조건으로 이미 PAID/FAILED 상태 멤버에게는 영향 없음.
+        기존 순차 루프에서는 이 멤버들이 자동으로 PAYMENT_PENDING에 남았으므로, 동작을 명시적으로 복원.
+    -->
+    <update id="resetProcessingToPaymentPending">
+        UPDATE party_cycle_member_payment
+        SET status     = 'PAYMENT_PENDING',
+            updated_at = NOW()
+        WHERE party_cycle_id  = #{partyCycleId}
+          AND status          = 'PROCESSING'
+          AND party_member_id IN
+          <foreach collection="memberIds" item="id" open="(" separator="," close=")">
+              #{id}
+          </foreach>
+    </update>
+
+    <!--
+        성능 개선: N회 개별 insertIfAbsent → 1회 배치 INSERT IGNORE
+        멱등성: INSERT IGNORE로 idempotency_key 유니크 제약 위반 시 무시 (기존 insertIfAbsent와 동일)
+        주의: payments 리스트가 비어 있으면 호출하지 말 것 (빈 VALUES 절은 SQL 오류)
+    -->
+    <insert id="batchInsertIfAbsent" parameterType="list">
+        INSERT IGNORE INTO party_cycle_member_payment (
+            party_cycle_id,
+            party_id,
+            party_member_id,
+            user_id,
+            amount,
+            status,
+            idempotency_key,
+            created_at,
+            updated_at
+        ) VALUES
+        <foreach collection="payments" item="p" separator=",">
+            (
+                #{p.partyCycleId},
+                #{p.partyId},
+                #{p.partyMemberId},
+                #{p.userId},
+                #{p.amount},
+                #{p.status},
+                #{p.idempotencyKey},
+                #{p.createdAt},
+                #{p.updatedAt}
+            )
+        </foreach>
+    </insert>
+
 </mapper>


### PR DESCRIPTION
## 문제 정의
기존 결제 실행 경로는 retry -> afterCommit -> publishEvent -> execute()가 사실상 동기처럼 동작하면서, PG I/O 구간 동안 HTTP 스레드와 DB 커넥션 점유가 길어져 tail latency(p95/p99) 급등이 발생했다.
추가로 리팩토링 과정에서 fail-fast 시 미처리 멤버가 PROCESSING에 잔존해, 재시도 시 재청구 대상에서 빠질 수 있는 상태 버그가 있었다.

## 변경 목적
1.HTTP 요청 스레드 즉시 반환 (비동기 이벤트 실행)
2.PG I/O 구간에서 DB 커넥션 미점유 (3-Phase 트랜잭션)
3.fail-fast 이후 미처리 멤버 상태 복구로 retry 재청구 가능 보장
4.STUB 기반 성능 검증 가능하도록 결제 클라이언트 추상화


## 핵심 변경사항
•PaymentExecutionRequestedEventListener
◦@Async("paymentExecutor") 적용
◦이벤트 핸들러를 payment 전용 executor에서 실행
•PaymentAsyncConfig (신규)
◦@EnableAsync
◦paymentExecutor 설정: core=40, max=80, queue=200, CallerRunsPolicy
•AutoPaymentService
◦단일 긴 TX 제거
◦TransactionTemplate(REQUIRES_NEW) 기반 3-Phase로 분리
▪Phase1: 선점/타겟확정/초기화/PROCESSING 마킹
▪Phase2: PG 호출(무TX)
▪Phase3: 결과 기록/상태전환/이벤트 등록
◦fail-fast 보강:
▪resetUnprocessedClaimedMembers(...) 추가
▪PG 미호출 멤버 PROCESSING -> PAYMENT_PENDING 복구
•PartyCycleMemberPaymentMapper + XML
◦batchInsertIfAbsent(...) 추가 (배치 INSERT IGNORE)
◦resetProcessingToPaymentPending(...) 추가
•결제 클라이언트 추상화
◦PaymentGatewayClient 인터페이스 도입
◦TossPaymentClient implements PaymentGatewayClient
◦StubPaymentClient + StubPaymentProperties 신규
◦BillingKeyService 의존성 TossPaymentClient -> PaymentGatewayClient로 전환
•설정
◦application-local.yml: payment.provider=stub
◦application-prod.yml: payment.provider=toss
◦로컬 부하 검증용 hikari/tomcat 파라미터 반영

## 성능 검증 결과 (STUB 부하테스트)
•환경: payment.provider=stub
•결과:
◦RPS: 258.38
◦Failures: 0%
◦Median: 91ms
◦p95: 520ms
◦p99: 1300ms
◦Avg: 162.87ms
•이전 기준 대비(공유 베이스라인):
◦RPS +29.7% (199.22 -> 258.38)
◦p95 -71.1% (1800ms -> 520ms)
◦p99 -61.8% (3400ms -> 1300ms)
◦Avg -70.0% (543.53ms -> 162.87ms)

## 수동 검증 범위
•자동결제 트리거 후 cycle 상태 전이 확인
•party_cycle_member_payment 상태 집계 확인
•retry 후 재청구 동작 확인
•fail-fast 시 미처리 멤버 복구 쿼리 경로 확인

## 리스크 / 트레이드오프
•@Async 도입으로 “큐 적재 후 프로세스 비정상 종료” 구간 유실 가능성 존재
•현재 복구 전략:
◦Deadline 처리(PAYMENT_PENDING/PROCESSING -> FAILED)
◦admin retry 재호출
•완전 내구성 필요 시 Outbox 패턴 별도 도입 필요

## 롤백 전략
1.리스너 @Async 제거하여 동기 실행으로 복귀
2.AutoPaymentService를 단일 TX 구조로 복귀
3.batchInsertIfAbsent/resetProcessingToPaymentPending 호출 제거 후 기존 insert 흐름 복귀
4.provider 설정을 toss로 고정

## 참고
•이번 PR은 성능 병목 제거 + 상태복구 보강이 범위다.
•장문 운영 문서성 내용은 코드 주석이 아니라 PR/ADR로 관리한다

#164 closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 비동기 결제 처리 기능 추가로 결제 요청 대기 시간 감소
  * Stub 결제 제공자 추가로 로컬 테스트 환경 개선
  * 배치 결제 처리 및 실패 시 상태 복구 기능 구현

* **Refactor**
  * 결제 처리 흐름을 트랜잭션 템플릿 기반으로 개선
  * 결제 게이트웨이 추상화 인터페이스 도입으로 확장성 향상

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->