### PR TITLE
refactor: responded_user_ids JSON 방식을 device_detection_response 테이블로 정규화

### DIFF
--- a/src/main/java/pbl2/sub119/backend/concurrent/entity/DeviceDetectionEvent.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/entity/DeviceDetectionEvent.java
@@ -22,10 +22,6 @@ public class DeviceDetectionEvent {
     private LocalDateTime detectedAt;
     private DeviceDetectionStatus status;
     private String notifiedUserIds;   // TEXT 컬럼, "[1,2,3]" JSON 배열 문자열
-    private String respondedUserIds;  // TEXT 컬럼, 응답 완료 유저 ID JSON 배열
-    private int responseCount;
-    private int mineCount;
-    private int unknownCount;
     private LocalDateTime expiresAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/pbl2/sub119/backend/concurrent/entity/DeviceDetectionResponse.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/entity/DeviceDetectionResponse.java
@@ -1,0 +1,20 @@
+package pbl2.sub119.backend.concurrent.entity;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeviceDetectionResponse {
+
+    private Long id;
+    private Long detectionEventId;
+    private Long userId;
+    private boolean mine;
+    private LocalDateTime respondedAt;
+}

--- a/src/main/java/pbl2/sub119/backend/concurrent/mapper/DeviceDetectionMapper.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/mapper/DeviceDetectionMapper.java
@@ -20,15 +20,7 @@ public interface DeviceDetectionMapper {
             @Param("status") DeviceDetectionStatus status
     );
 
-    void incrementMineCount(@Param("id") Long id);
-
-    void incrementUnknownCount(@Param("id") Long id);
-
-    void incrementResponseCount(@Param("id") Long id);
-
     DeviceDetectionEvent findByIdForUpdate(@Param("id") Long id);
-
-    void updateRespondedUserIds(@Param("id") Long id, @Param("respondedUserIds") String respondedUserIds);
 
     // 상태 전환 1회 보장: PENDING 상태일 때만 업데이트, 영향 행 수 반환
     int updateStatusIfPending(@Param("id") Long id, @Param("status") DeviceDetectionStatus status);

--- a/src/main/java/pbl2/sub119/backend/concurrent/mapper/DeviceDetectionResponseMapper.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/mapper/DeviceDetectionResponseMapper.java
@@ -1,0 +1,25 @@
+package pbl2.sub119.backend.concurrent.mapper;
+
+import java.util.List;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import pbl2.sub119.backend.concurrent.entity.DeviceDetectionResponse;
+
+@Mapper
+public interface DeviceDetectionResponseMapper {
+
+    void insert(DeviceDetectionResponse response);
+
+    boolean existsByEventIdAndUserId(
+            @Param("eventId") Long eventId,
+            @Param("userId") Long userId
+    );
+
+    int countByEventId(@Param("eventId") Long eventId);
+
+    int countMineByEventId(@Param("eventId") Long eventId);
+
+    int countUnknownByEventId(@Param("eventId") Long eventId);
+
+    List<Long> findRespondedUserIdsByEventId(@Param("eventId") Long eventId);
+}

--- a/src/main/java/pbl2/sub119/backend/concurrent/scheduler/EscalationScheduler.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/scheduler/EscalationScheduler.java
@@ -12,6 +12,7 @@ import pbl2.sub119.backend.concurrent.entity.DeviceDetectionEvent;
 import pbl2.sub119.backend.concurrent.enumerated.DeviceDetectionStatus;
 import pbl2.sub119.backend.concurrent.mapper.ConcurrentIncidentMapper;
 import pbl2.sub119.backend.concurrent.mapper.DeviceDetectionMapper;
+import pbl2.sub119.backend.concurrent.mapper.DeviceDetectionResponseMapper;
 import pbl2.sub119.backend.concurrent.service.EscalationService;
 import pbl2.sub119.backend.concurrent.service.IncidentService;
 import pbl2.sub119.backend.notification.enumerated.NotificationType;
@@ -29,6 +30,7 @@ public class EscalationScheduler {
 
     private final ConcurrentIncidentMapper incidentMapper;
     private final DeviceDetectionMapper deviceDetectionMapper;
+    private final DeviceDetectionResponseMapper deviceDetectionResponseMapper;
     private final PartyMapper partyMapper;
     private final SubProductMapper subProductMapper;
     private final EscalationService escalationService;
@@ -124,7 +126,7 @@ public class EscalationScheduler {
 
         for (final DeviceDetectionEvent event : targets) {
             try {
-                if (event.getMineCount() == 0) {
+                if (deviceDetectionResponseMapper.countMineByEventId(event.getId()) == 0) {
                     incidentService.processWarningFromDeviceDetection(event.getPartyId());
                 }
                 escalationService.recordNoResponseViolations(event);

--- a/src/main/java/pbl2/sub119/backend/concurrent/service/DeviceDetectionService.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/service/DeviceDetectionService.java
@@ -19,14 +19,14 @@ import pbl2.sub119.backend.party.common.entity.Party;
 import pbl2.sub119.backend.party.common.mapper.PartyMapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import pbl2.sub119.backend.concurrent.dto.request.DeviceReportRequest;
 import pbl2.sub119.backend.concurrent.dto.response.DeviceReportResult;
+import pbl2.sub119.backend.concurrent.entity.DeviceDetectionResponse;
 import pbl2.sub119.backend.concurrent.entity.PartyMemberDevice;
+import pbl2.sub119.backend.concurrent.mapper.DeviceDetectionResponseMapper;
 import pbl2.sub119.backend.party.common.entity.PartyMember;
 import pbl2.sub119.backend.party.common.mapper.PartyMemberMapper;
 
@@ -35,6 +35,7 @@ import pbl2.sub119.backend.party.common.mapper.PartyMemberMapper;
 public class DeviceDetectionService {
 
     private final DeviceDetectionMapper deviceDetectionMapper;
+    private final DeviceDetectionResponseMapper deviceDetectionResponseMapper;
     private final PartyMemberDeviceMapper partyMemberDeviceMapper;
     private final PartyMapper partyMapper;
     private final PartyMemberMapper partyMemberMapper;
@@ -106,7 +107,7 @@ public class DeviceDetectionService {
 
     @Transactional
     public DeviceResponseResult respond(final Long alertId, final Long userId, final boolean isMyDevice) {
-        // FOR UPDATE로 행 락을 잡아 동시 중복 응답 방지
+        // FOR UPDATE로 행 락을 잡아 동시 요청 직렬화
         final DeviceDetectionEvent event = deviceDetectionMapper.findByIdForUpdate(alertId);
         if (event == null) {
             throw new ConcurrentException(ErrorCode.DEVICE_ALERT_NOT_FOUND);
@@ -119,33 +120,33 @@ public class DeviceDetectionService {
             throw new ConcurrentException(ErrorCode.CONCURRENT_NOT_PARTY_MEMBER);
         }
 
-        final List<Long> respondedIds = parseRespondedUserIds(event.getRespondedUserIds());
-        if (respondedIds.contains(userId)) {
+        // 중복 응답 체크 — DB UNIQUE 제약이 최후 방어선이지만 사전 체크로 명확한 에러 반환
+        if (deviceDetectionResponseMapper.existsByEventIdAndUserId(alertId, userId)) {
             throw new ConcurrentException(ErrorCode.DEVICE_ALERT_ALREADY_RESPONDED);
         }
-        respondedIds.add(userId);
-        try {
-            deviceDetectionMapper.updateRespondedUserIds(alertId, objectMapper.writeValueAsString(respondedIds));
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException("응답자 목록 직렬화 실패. alertId=" + alertId, e);
-        }
+
+        deviceDetectionResponseMapper.insert(DeviceDetectionResponse.builder()
+                .detectionEventId(alertId)
+                .userId(userId)
+                .mine(isMyDevice)
+                .respondedAt(LocalDateTime.now())
+                .build());
 
         if (isMyDevice) {
-            // 1명이라도 본인 기기라고 확인하면 즉시 CONFIRMED_MINE — 비밀번호 변경 불필요, 동시접속 규칙 경고
-            deviceDetectionMapper.incrementMineCount(alertId);
+            // 1명이라도 본인 기기라고 확인하면 즉시 CONFIRMED_MINE
             final int affected = deviceDetectionMapper.updateStatusIfPending(alertId, DeviceDetectionStatus.CONFIRMED_MINE);
             if (affected > 0) {
                 notifyMembersOnConfirmedMine(event);
             }
         } else {
-            deviceDetectionMapper.incrementUnknownCount(alertId);
             // 알림 대상자 전원이 응답했고 아무도 내 기기라고 하지 않은 경우 → REPORTED_UNKNOWN → 인시던트 경고 처리
-            final DeviceDetectionEvent updated = deviceDetectionMapper.findById(alertId);
-            final List<Long> notifiedIds = parseRespondedUserIds(updated.getNotifiedUserIds());
-            if (respondedIds.containsAll(notifiedIds) && updated.getMineCount() == 0) {
+            final List<Long> notifiedIds = parseNotifiedUserIds(event.getNotifiedUserIds());
+            final int responseCount = deviceDetectionResponseMapper.countByEventId(alertId);
+            final int mineCount = deviceDetectionResponseMapper.countMineByEventId(alertId);
+            if (responseCount >= notifiedIds.size() && mineCount == 0) {
                 final int affected = deviceDetectionMapper.updateStatusIfPending(alertId, DeviceDetectionStatus.REPORTED_UNKNOWN);
                 if (affected > 0) {
-                    incidentService.processWarningFromDeviceDetection(updated.getPartyId());
+                    incidentService.processWarningFromDeviceDetection(event.getPartyId());
                 }
             }
         }
@@ -154,9 +155,9 @@ public class DeviceDetectionService {
         return DeviceResponseResult.builder()
                 .alertId(alertId)
                 .status(result.getStatus())
-                .mineCount(result.getMineCount())
-                .unknownCount(result.getUnknownCount())
-                .responseCount(result.getResponseCount())
+                .mineCount(deviceDetectionResponseMapper.countMineByEventId(alertId))
+                .unknownCount(deviceDetectionResponseMapper.countUnknownByEventId(alertId))
+                .responseCount(deviceDetectionResponseMapper.countByEventId(alertId))
                 .build();
     }
 
@@ -179,14 +180,14 @@ public class DeviceDetectionService {
         }
     }
 
-    private List<Long> parseRespondedUserIds(final String json) {
+    private List<Long> parseNotifiedUserIds(final String json) {
         if (json == null || json.isBlank()) {
-            return new ArrayList<>();
+            return List.of();
         }
         try {
-            return objectMapper.readValue(json, new TypeReference<List<Long>>() {});
+            return objectMapper.readValue(json, new com.fasterxml.jackson.core.type.TypeReference<List<Long>>() {});
         } catch (JsonProcessingException e) {
-            return new ArrayList<>();
+            return List.of();
         }
     }
 }

--- a/src/main/java/pbl2/sub119/backend/concurrent/service/EscalationService.java
+++ b/src/main/java/pbl2/sub119/backend/concurrent/service/EscalationService.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +16,7 @@ import pbl2.sub119.backend.concurrent.entity.UserViolationRecord;
 import pbl2.sub119.backend.concurrent.enumerated.IncidentStatus;
 import pbl2.sub119.backend.concurrent.enumerated.ViolationType;
 import pbl2.sub119.backend.concurrent.mapper.ConcurrentIncidentMapper;
+import pbl2.sub119.backend.concurrent.mapper.DeviceDetectionResponseMapper;
 import pbl2.sub119.backend.concurrent.mapper.UserViolationRecordMapper;
 import pbl2.sub119.backend.notification.enumerated.NotificationType;
 import pbl2.sub119.backend.notification.service.NotificationCommandService;
@@ -42,6 +42,7 @@ public class EscalationService {
     private final MatchWaitingQueueMapper matchWaitingQueueMapper;
     private final ConcurrentIncidentMapper incidentMapper;
     private final UserViolationRecordMapper violationRecordMapper;
+    private final DeviceDetectionResponseMapper deviceDetectionResponseMapper;
     private final ObjectMapper objectMapper;
     private final NotificationCommandService notificationCommandService;
     private final SmsMessageTemplateService smsTemplate;
@@ -113,8 +114,8 @@ public class EscalationService {
 
     @Transactional
     public void recordNoResponseViolations(final DeviceDetectionEvent event) {
-        final List<Long> notifiedIds = parseUserIds(event.getNotifiedUserIds());
-        final List<Long> respondedIds = parseUserIds(event.getRespondedUserIds());
+        final List<Long> notifiedIds = parseNotifiedUserIds(event.getNotifiedUserIds());
+        final List<Long> respondedIds = deviceDetectionResponseMapper.findRespondedUserIdsByEventId(event.getId());
 
         for (final Long userId : notifiedIds) {
             if (!respondedIds.contains(userId)) {
@@ -128,14 +129,14 @@ public class EscalationService {
         }
     }
 
-    private List<Long> parseUserIds(final String json) {
+    private List<Long> parseNotifiedUserIds(final String json) {
         if (json == null || json.isBlank()) {
-            return new ArrayList<>();
+            return List.of();
         }
         try {
             return objectMapper.readValue(json, new TypeReference<List<Long>>() {});
         } catch (JsonProcessingException e) {
-            return new ArrayList<>();
+            return List.of();
         }
     }
 }

--- a/src/main/resources/mapper/concurrent/DeviceDetectionMapper.xml
+++ b/src/main/resources/mapper/concurrent/DeviceDetectionMapper.xml
@@ -14,10 +14,6 @@
         <result property="status" column="status"
                 javaType="pbl2.sub119.backend.concurrent.enumerated.DeviceDetectionStatus"/>
         <result property="notifiedUserIds" column="notified_user_ids"/>
-        <result property="respondedUserIds" column="responded_user_ids"/>
-        <result property="responseCount" column="response_count"/>
-        <result property="mineCount" column="mine_count"/>
-        <result property="unknownCount" column="unknown_count"/>
         <result property="expiresAt" column="expires_at"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -48,35 +44,10 @@
         WHERE id = #{id}
     </update>
 
-    <update id="incrementMineCount">
-        UPDATE device_detection_event
-        SET mine_count = mine_count + 1, response_count = response_count + 1, updated_at = NOW()
-        WHERE id = #{id}
-    </update>
-
-    <update id="incrementUnknownCount">
-        UPDATE device_detection_event
-        SET unknown_count = unknown_count + 1, response_count = response_count + 1, updated_at = NOW()
-        WHERE id = #{id}
-    </update>
-
-    <update id="incrementResponseCount">
-        UPDATE device_detection_event
-        SET response_count = response_count + 1, updated_at = NOW()
-        WHERE id = #{id}
-    </update>
-
-    <!-- FOR UPDATE로 행 락을 걸고 Java에서 중복 체크 후 갱신 -->
+    <!-- FOR UPDATE로 행 락을 걸고 DB UNIQUE 제약으로 중복 응답 방지 -->
     <select id="findByIdForUpdate" resultMap="deviceDetectionResultMap">
         SELECT * FROM device_detection_event WHERE id = #{id} FOR UPDATE
     </select>
-
-    <update id="updateRespondedUserIds">
-        UPDATE device_detection_event
-        SET responded_user_ids = #{respondedUserIds},
-            updated_at = NOW()
-        WHERE id = #{id}
-    </update>
 
     <!-- 상태 전환 1회 보장: PENDING일 때만 업데이트 -->
     <update id="updateStatusIfPending">

--- a/src/main/resources/mapper/concurrent/DeviceDetectionResponseMapper.xml
+++ b/src/main/resources/mapper/concurrent/DeviceDetectionResponseMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="pbl2.sub119.backend.concurrent.mapper.DeviceDetectionResponseMapper">
+
+    <insert id="insert" parameterType="pbl2.sub119.backend.concurrent.entity.DeviceDetectionResponse"
+            useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO device_detection_response (detection_event_id, user_id, mine, responded_at)
+        VALUES (#{detectionEventId}, #{userId}, #{mine}, #{respondedAt})
+    </insert>
+
+    <select id="existsByEventIdAndUserId" resultType="boolean">
+        SELECT COUNT(1) > 0
+        FROM device_detection_response
+        WHERE detection_event_id = #{eventId}
+          AND user_id = #{userId}
+    </select>
+
+    <select id="countByEventId" resultType="int">
+        SELECT COUNT(1)
+        FROM device_detection_response
+        WHERE detection_event_id = #{eventId}
+    </select>
+
+    <select id="countMineByEventId" resultType="int">
+        SELECT COUNT(1)
+        FROM device_detection_response
+        WHERE detection_event_id = #{eventId}
+          AND mine = 1
+    </select>
+
+    <select id="countUnknownByEventId" resultType="int">
+        SELECT COUNT(1)
+        FROM device_detection_response
+        WHERE detection_event_id = #{eventId}
+          AND mine = 0
+    </select>
+
+    <select id="findRespondedUserIdsByEventId" resultType="long">
+        SELECT user_id
+        FROM device_detection_response
+        WHERE detection_event_id = #{eventId}
+    </select>
+
+</mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -468,13 +468,24 @@ CREATE TABLE IF NOT EXISTS device_detection_event (
     detected_at         DATETIME NOT NULL,
     status              VARCHAR(30) NOT NULL DEFAULT 'PENDING',
     notified_user_ids   TEXT,
-    responded_user_ids  TEXT NULL,
-    response_count      INT NOT NULL DEFAULT 0,
-    mine_count          INT NOT NULL DEFAULT 0,
-    unknown_count       INT NOT NULL DEFAULT 0,
     expires_at          DATETIME NOT NULL,
     created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+ALTER TABLE device_detection_event DROP COLUMN IF EXISTS responded_user_ids;
+ALTER TABLE device_detection_event DROP COLUMN IF EXISTS response_count;
+ALTER TABLE device_detection_event DROP COLUMN IF EXISTS mine_count;
+ALTER TABLE device_detection_event DROP COLUMN IF EXISTS unknown_count;
+
+-- device_detection_response (2026.05.29 / khj)
+CREATE TABLE IF NOT EXISTS device_detection_response (
+    id                  BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    detection_event_id  BIGINT NOT NULL,
+    user_id             BIGINT NOT NULL,
+    mine                TINYINT(1) NOT NULL DEFAULT 0,
+    responded_at        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_device_response UNIQUE (detection_event_id, user_id)
 );
 
 -- party_member_device (2026.05.21 / khj)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 기기 감지 이벤트에 만료 시간 기능 추가
  * 사용자 응답 추적 시스템 개선 및 구조 최적화

* **버그 수정**
  * 응답 집계 로직 안정성 향상
  * 중복 응답 방지 메커니즘 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2026-GNU-PBL2/BE/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->